### PR TITLE
fix: various guidebooks have a topmatter codeblock match of .*

### DIFF
--- a/guidebooks/ibm/cloud/cli/ibmcloud.md
+++ b/guidebooks/ibm/cloud/cli/ibmcloud.md
@@ -1,29 +1,35 @@
----
-codeblocks:
-    - match: .*
-      validate: which ibmcloud
----
-
 # Install the IBM Cloud CLI
 
 The installation command in this tutorial installs the latest stand-alone IBM Cloud CLI version available.
 
 === "MacOS"
     ```shell
+    ---
+    validate: which ibmcloud
+    ---
     curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
     ```
     
 === "Linux"
     ```shell
+    ---
+    validate: which ibmcloud
+    ---
     curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
     ```
 
 === "Windows"
     ```shell
+    ---
+    validate: which ibmcloud
+    ---
     iex(New-Object Net.WebClient).DownloadString('https://clis.cloud.ibm.com/install/powershell')
     ```
 
 === "Windows Subsystem for Linux"
     ```shell
+    ---
+    validate: which ibmcloud
+    ---
     curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
     ```

--- a/guidebooks/ibm/cloud/cli/plugins/cloud-object-storage.md
+++ b/guidebooks/ibm/cloud/cli/plugins/cloud-object-storage.md
@@ -1,9 +1,6 @@
 ---
 imports:
     - ../ibmcloud.md
-codeblocks:
-    - match: .*
-      validate: ibmcloud cos
 ---
 
 # Install the IBM CLoud Cloud Object Storage CLI Plugin
@@ -11,5 +8,8 @@ codeblocks:
 The installation command in this tutorial installs the latest stand-alone IBM Cloud CLI Cloud Object Storage plugin version available.
 
 ```shell
+---
+validate: ibmcloud cos
+---
 ibmcloud plugin install cloud-object-storage
 ```

--- a/guidebooks/ibm/cloud/cli/plugins/codeengine.md
+++ b/guidebooks/ibm/cloud/cli/plugins/codeengine.md
@@ -1,9 +1,6 @@
 ---
 imports:
     - ../ibmcloud.md
-codeblocks:
-    - match: .*
-      validate: ibmcloud ce
 ---
 
 # Install the IBM CLoud CodeEngine CLI Plugin
@@ -11,5 +8,8 @@ codeblocks:
 The installation command in this tutorial installs the latest stand-alone IBM Cloud CLI CodeEngine plugin version available.
 
 ```shell
+---
+validate: ibmcloud ce
+---
 ibmcloud plugin install code-engine
 ```

--- a/guidebooks/ibm/cloud/login.md
+++ b/guidebooks/ibm/cloud/login.md
@@ -2,9 +2,6 @@
 barrier: true
 imports: 
     - ./cli/ibmcloud.md
-codeblocks:
-    - match: .*
-      validate: ibmcloud target | tail -1 | grep -qv "Not logged in"
 ---
 
 # IBM Cloud: Log in
@@ -15,17 +12,26 @@ Cloud](https://www.ibm.com/cloud). Select your authentication method.
 === "Single Sign-on/OTP"
     You may use your browser to acquire a one-time password.
     ```shell
+    ---
+    validate: ibmcloud target | tail -1 | grep -qv "Not logged in"
+    ---
     ibmcloud login --sso
     ```
     
 === "Username and Password"
     Normal accounts can be authenticated using a username and password.
     ```shell
+    ---
+    validate: ibmcloud target | tail -1 | grep -qv "Not logged in"
+    ---
     ibmcloud login
     ```
 
 === "Authenticate with apikey"
     If you have a acquired an [IBM Cloud apikey](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=servers-creating-cloud-api-key), you can avoid having to periodically re-authenticate.
     ```shell
+    ---
+    validate: ibmcloud target | tail -1 | grep -qv "Not logged in"
+    ---
     ibmcloud login --apikey=@~/.config/ibm/apikey
     ```

--- a/guidebooks/ibm/cloud/target.md
+++ b/guidebooks/ibm/cloud/target.md
@@ -2,7 +2,7 @@
 imports:
     - ./login.md
 codeblocks:
-    - match: .*
+    - match: ibmcloud resource groups
       validate: ibmcloud target | grep 'Resource group:' | cut -d ':' -f2 | sed -e 's/^[[:space:]]*//' | grep -qv 'No resource group targeted'
 ---
 


### PR DESCRIPTION
this will match everything in every imported guidebook