### PR TITLE
fix: increase sleep delay in ibm/cloud/ce/job/run

### DIFF
--- a/guidebooks/ibm/cloud/ce/job/run.md
+++ b/guidebooks/ibm/cloud/ce/job/run.md
@@ -23,6 +23,6 @@ information that is used each time that the job is run.
 
     ```shell
     ibmcloud ce jobrun submit --image icr.io/codeengine/firstjob --name helloworld-${uuid}
-    sleep 1
+    sleep 3
     ibmcloud ce jobrun logs -f --jobrun helloworld-${uuid}
     ```


### PR DESCRIPTION
this is due to a bug in the `ibmcloud ce` plugin