### PR TITLE
doc: update bert to use conda run

### DIFF
--- a/guidebooks/ml/codeflare/training/bert/index.md
+++ b/guidebooks/ml/codeflare/training/bert/index.md
@@ -21,12 +21,11 @@ conda env create --name ml.codeflare.training.bert -f https://raw.githubusercont
 
 ```shell
 ---
-validate: "[ -f ray-bert-vanilla.py ]"
+validate: "[ -f /tmp/ray-bert-vanilla.py ]"
 ---
-curl -LO https://raw.githubusercontent.com/guidebooks/store/main/guidebooks/ml/codeflare/training/bert/ray-bert-vanilla.py
+curl -L https://raw.githubusercontent.com/guidebooks/store/main/guidebooks/ml/codeflare/training/bert/ray-bert-vanilla.py | sed 's/address="auto"//' > /tmp/ray-bert-vanilla.py
 ```
 
 ```shell
-conda activate ml.codeflare.training.bert
-python -u ray-bert-vanilla.py
+conda run --no-capture-output -n ml.codeflare.training.bert python -u /tmp/ray-bert-vanilla.py --datapath /tmp/ --modelpath /tmp/
 ```


### PR DESCRIPTION
This PR also fixes the validator, and uses the datapath and modelpath arguments, pointing them to /tmp