### PR TITLE
fix: avoid using "pip show" for validator

### DIFF
--- a/guidebooks/ml/ray/install/index.md
+++ b/guidebooks/ml/ray/install/index.md
@@ -8,7 +8,7 @@
 
         ```shell
         ---
-        validate: pip show ray
+        validate: python3 -c "import ray"
         ---
         pip install -U ray
         ```

--- a/guidebooks/python/pip/pyarrow.md
+++ b/guidebooks/python/pip/pyarrow.md
@@ -16,7 +16,7 @@ based on the C++ implementation of Arrow.
 
 ```shell
 ---
-validate: pip show pyarrow
+validate: python3 -c "import pyarrow"
 ---
 pip install pyarrow
 ```


### PR DESCRIPTION
it seems to be a lot faster to do a `python3 -c "import foo"` versus `pip show foo`. perhaps 2x faster? saving 500ms?