### PR TITLE
chore: remove crufty ml/run/run/examples

### DIFF
--- a/guidebooks/ml/ray/run/examples/index.md
+++ b/guidebooks/ml/ray/run/examples/index.md
@@ -1,8 +1,0 @@
-=== "Example: Using Ray Tasks to Parallelize a Function"
-    --8<-- "tasks.md"
-
-=== "Example: Using Ray Actors to Parallelize a Class"
-    --8<-- "actors.md"
-
-=== "Example: Creating and Transforming Datasets"
-    --8<-- "dataset/index.md"


### PR DESCRIPTION
This should have been removed in https://github.com/guidebooks/store/pull/74