### PR TITLE
feat: update ray submit examples to use a self-generated job id

### DIFF
--- a/guidebooks/ml/ray/run/core/actors.md
+++ b/guidebooks/ml/ray/run/core/actors.md
@@ -1,10 +1,15 @@
+---
+imports:
+    - ../../start/index.md
+---
+
 # Ray Core: Parallelizing Classes with Ray Actors
 
 Ray provides actors to allow you to parallelize an instance of a class in Python or Java. When you instantiate a class that is a Ray actor, Ray will start a remote instance of that class in the cluster. This actor can then execute remote method calls and maintain its own internal state.
 
 ```python
 ---
-exec: ray-submit
+exec: ray-submit --job-id ${uuid} --no-wait
 ---
 import ray
 ray.init() # Only call this once.
@@ -24,4 +29,8 @@ counters = [Counter.remote() for i in range(4)]
 [c.increment.remote() for c in counters]
 futures = [c.read.remote() for c in counters]
 print(ray.get(futures)) # [1, 1, 1, 1]
+```
+
+```shell
+ray job logs -f ${uuid} 2> /dev/null
 ```

--- a/guidebooks/ml/ray/run/core/tasks.md
+++ b/guidebooks/ml/ray/run/core/tasks.md
@@ -1,3 +1,8 @@
+---
+imports:
+    - ../../start/index.md
+---
+
 # Ray Core: Parallelizing Functions with Ray Tasks
 
 First, you import Ray and and initialize it with `ray.init()`. Then
@@ -9,7 +14,7 @@ future, a so-called Ray object reference, that you can then fetch with
 
 ```python
 ---
-exec: ray-submit
+exec: ray-submit --job-id ${uuid} --no-wait
 ---
 import ray
 ray.init()

--- a/guidebooks/ml/ray/run/data/create/from-file.md
+++ b/guidebooks/ml/ray/run/data/create/from-file.md
@@ -1,5 +1,6 @@
 ---
 imports:
+    - ../../../start/index.md
     - ../../../../../../python/pip/tqdm.md
     - ../../../../../../python/pip/pyarrow.md
 ---
@@ -20,7 +21,7 @@ operation is finished. Datasets also supports `.filter()` and
 
 ```python
 ---
-exec: ray-submit
+exec: ray-submit --job-id ${uuid} --no-wait
 ---
 import ray
 import pandas as pd

--- a/guidebooks/ml/ray/run/data/create/from-range.md
+++ b/guidebooks/ml/ray/run/data/create/from-range.md
@@ -1,3 +1,8 @@
+---
+imports:
+    - ../../../start/index.md
+---
+
 Get started by creating Datasets from synthetic data using
 `ray.data.range()` and `ray.data.from_items()`. Datasets can hold
 either plain Python objects (schema is a Python type), or
@@ -6,7 +11,7 @@ Arrow](https://arrow.apache.org/docs/python/api/datatypes.html)).
 
 ```python
 ---
-exec: ray-submit
+exec: ray-submit --job-id ${uuid} --no-wait
 ---
 import ray
 

--- a/guidebooks/ml/ray/run/serve/examples/gradient-boosting.md
+++ b/guidebooks/ml/ray/run/serve/examples/gradient-boosting.md
@@ -1,5 +1,6 @@
 ---
 imports:
+    - ../../../start/index.md
     - ../../../install/serve.md
 ---
 
@@ -9,7 +10,7 @@ imports:
 
 ```python
 ---
-exec: ray-submit
+exec: ray-submit --job-id ${uuid} --no-wait
 ---
 # This example runs serves a [scikit-learn](https://scikit-learn.org/) gradient boosting classifier.
 
@@ -50,4 +51,8 @@ sample_request_input = {"vector": [1.2, 1.0, 1.1, 0.9]}
 response = requests.get(
     "http://localhost:8000/iris", json=sample_request_input)
 print(response.text)
+```
+
+```shell
+ray job logs -f ${uuid} 2> /dev/null
 ```

--- a/guidebooks/ml/ray/run/train/examples/pytorch/index.md
+++ b/guidebooks/ml/ray/run/train/examples/pytorch/index.md
@@ -1,5 +1,6 @@
 ---
 imports:
+    - ../../../../start/index.md
     - ../../../../../../python/pip/torch.md
 ---
 
@@ -9,7 +10,7 @@ This example shows how you can use Ray Train with PyTorch.
 
 ```python
 ---
-exec: ray-submit
+exec: ray-submit --job-id ${uuid} --no-wait
 ---
 # First, set up your dataset and model.
 --8<-- "nn.py"

--- a/guidebooks/ml/ray/run/tune/examples/grid-search.md
+++ b/guidebooks/ml/ray/run/tune/examples/grid-search.md
@@ -1,5 +1,6 @@
 ---
 imports:
+    - ../../../start/index.md
     - ../../../install/tune.md
 ---
 
@@ -9,7 +10,7 @@ imports:
 
 ```python
 ---
-exec: ray-submit
+exec: ray-submit --job-id ${uuid} --no-wait
 ---
 # This example runs a small grid search with an iterative training function.
 from ray import tune
@@ -29,4 +30,8 @@ search_space = {
 # 3. Start a Tune run and print the best result.
 analysis = tune.run(objective, config=search_space)
 print(analysis.get_best_config(metric="score", mode="min"))
+```
+
+```shell
+ray job logs -f ${uuid} 2>& /dev/null
 ```


### PR DESCRIPTION
as opposed to relying on `ray job submit` to generate a job id for us. this should help with fetching logs and status, since we are now in control of the job id