### PR TITLE
fix: remove trailing dot from IBM Cloud Object Storage endpoint urls

### DIFF
--- a/guidebooks/ibm/cloud/cos/instance.md
+++ b/guidebooks/ibm/cloud/cos/instance.md
@@ -50,13 +50,13 @@ imports:
 Access your data via this HTTP endpoint.
 
 ```shell
-export S3_ENDPOINT="https://s3.${IBM_CLOUD_REGION}.cloud-object-storage.appdomain.cloud."
+export S3_ENDPOINT="https://s3.${IBM_CLOUD_REGION}.cloud-object-storage.appdomain.cloud"
 ```
 
 For intra-cloud data fetches, you can use the lower-cost "direct" endpoint.
 
 ```shell
-export S3_DIRECT_ENDPOINT="https://s3.direct.${IBM_CLOUD_REGION}.cloud-object-storage.appdomain.cloud."
+export S3_DIRECT_ENDPOINT="https://s3.direct.${IBM_CLOUD_REGION}.cloud-object-storage.appdomain.cloud"
 ```
 
 --8<-- "_auth.md"


### PR DESCRIPTION
the python boto3 client does not seem to like it with trailing dots, sigh