### PR TITLE
fix: ml/ray/stop/kubernetes may fail if finalizer hack fails

### DIFF
--- a/guidebooks/ml/ray/stop/kubernetes.md
+++ b/guidebooks/ml/ray/stop/kubernetes.md
@@ -21,7 +21,7 @@ kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} delete raycluster ${RAY_KUBE_CLU
 
 ```shell
 sleep 2
-kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} patch raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} -p '{"metadata":{"finalizers":null}}' --type=merge
+kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} patch raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} -p '{"metadata":{"finalizers":null}}' --type=merge 2> /dev/null || exit 0
 ```
 
 ## Delete Cluster


### PR DESCRIPTION
and the finalizer hack shouldn't cause the helm charts not to be removed