### PR TITLE
fix: remove uid-range import from ml/codeflare/training/ber

### DIFF
--- a/guidebooks/ml/codeflare/training/bert/index.md
+++ b/guidebooks/ml/codeflare/training/bert/index.md
@@ -1,7 +1,6 @@
 ---
 imports:
     - ../../../ray/start/index.md
-    - ../../../ray/hacks/openshift/uid-range.md
     - ../../../../util/jobid.md
     - ../../../../python/pip/torch.md
     - ../../../../python/pip/tensorflow.md


### PR DESCRIPTION
this is now part of the base ml/ray/start/kubernetes