### PR TITLE
feat: update ml/codeflare/tuning/glue to use runtime_env dependence injection

### DIFF
--- a/guidebooks/ml/codeflare/tuning/glue/conda.txt
+++ b/guidebooks/ml/codeflare/tuning/glue/conda.txt
@@ -1,0 +1,3 @@
+dataclasses
+transformers
+typing

--- a/guidebooks/ml/codeflare/tuning/glue/glue_benchmark.py
+++ b/guidebooks/ml/codeflare/tuning/glue/glue_benchmark.py
@@ -169,7 +169,7 @@ def Fetch_data_to_local_dir(logger,dataRefs,key):
 # Two log streams are created: a debug level stream to stdout and an info level to file
 # The results are packed into a python hashmap and returned
 
-@ray.remote(num_gpus=1)
+@ray.remote(num_gpus=int(os.environ.get("NUM_GPUS")) if "NUM_GPUS" in os.environ else 0)
 def Process_task(dataRefs,bucket,model,gluedata,task,seed,LR,savemodel):
   # clean and recreate result directory
   resultdir = ResultDir(model,task,seed,LR)

--- a/guidebooks/ml/codeflare/tuning/glue/index.md
+++ b/guidebooks/ml/codeflare/tuning/glue/index.md
@@ -2,11 +2,9 @@
 imports:
     - ./overrides.md
     - ../../../ray/start/index.md
-    - ../../../ray/hacks/openshift/uid-range.md
     - ../../../../util/jobid.md
     - ../../../../s3/choose/instance.md
     - ../../../../s3/choose/object.md
-    - ../../../../python/pip/boto3.md
 ---
 
 <!--    - ../../../../s3/create/kubernetes/secret-if-needed.md -->
@@ -18,6 +16,22 @@ The General Language Understanding Evaluation (GLUE) benchmark is a collection o
 - A benchmark of nine sentence- or sentence-pair language understanding tasks built on established existing datasets and selected to cover a diverse range of dataset sizes, text genres, and degrees of difficulty,
 - A diagnostic dataset designed to evaluate and analyze model performance with respect to a wide range of linguistic phenomena found in natural language, and
 - A public leaderboard for tracking performance on the benchmark and a dashboard for visualizing the performance of models on the diagnostic set.
+
+## Install Python Packages
+
+```shell
+---
+exec: pip-install
+---
+--8<-- "./pip.txt"
+```
+
+```shell
+---
+exec: conda-install
+---
+--8<-- "./conda.txt"
+```
 
 ## Run it
 

--- a/guidebooks/ml/codeflare/tuning/glue/overrides.md
+++ b/guidebooks/ml/codeflare/tuning/glue/overrides.md
@@ -1,3 +1,5 @@
+<!--
 ```shell
 export RAY_IMAGE=projectcodeflare/codeflare-glue:latest
 ```
+-->

--- a/guidebooks/ml/codeflare/tuning/glue/pip.txt
+++ b/guidebooks/ml/codeflare/tuning/glue/pip.txt
@@ -1,0 +1,2 @@
+boto3
+ray[default]


### PR DESCRIPTION
rather than relying on a custom base image

This PR also updates the `glue_benchmark.py` to set `num_gpus` depending on the `NUM_GPUS` environment variable, rather than hard-coding it to `1`