### PR TITLE
fix: allow for multiple s3 object selections

### DIFF
--- a/guidebooks/ml/codeflare/training/bert/index.md
+++ b/guidebooks/ml/codeflare/training/bert/index.md
@@ -1,6 +1,7 @@
 ---
 imports:
     - ml/ray/start
+    - ml/ray/run/logs-in-s3.md
     - util/jobid
 ---
 
@@ -26,17 +27,15 @@ export JOB_NAME=BERT
 ```
 
 ```shell
-export TB_LOGDIR=/tmp/tensorboard/${JOB_ID}
+export TB_LOGDIR="s3://${S3_BUCKETRAYLOGS}/codeflare/${JOB_ID}/"
 ```
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait -- --datapath /tmp/ --modelpath /tmp/ --logpath ${TB_LOGDIR} --num_workers ${NUM_GPUs-${NUM_CPUS-1}} ${GPU_OPTION}
+exec: ray-submit --job-id ${JOB_ID} --no-wait -- --datapath /tmp/ --modelpath /tmp/ --logpath /tmp/ --tblogpath "${TB_LOGDIR}" --num_workers ${NUM_GPUs-${NUM_CPUS-1}} ${GPU_OPTION}
 ---
 --8<-- "./ray-bert-vanilla.py"
 ```
 
---8<-- "ml/tensorflow/tensorboard/rsync"
 --8<-- "ml/tensorflow/tensorboard/run"
-
 --8<-- "ml/ray/run/logs"

--- a/guidebooks/ml/codeflare/training/bert/ray-bert-vanilla.py
+++ b/guidebooks/ml/codeflare/training/bert/ray-bert-vanilla.py
@@ -22,6 +22,7 @@ from ray.train import Trainer
 import tensorflow.summary as summary
 
 import argparse
+import importlib
 
 parser = argparse.ArgumentParser(description='BERT on WikiText-103 with Ray Train for OPC (now with TensorBoard!)')
 parser.add_argument('--num_workers', type=int, default=1, help='Number of workers to use for training')
@@ -30,12 +31,13 @@ parser.add_argument('--num_epochs', type=int, default=5, help='Number of passes 
 parser.add_argument('--datapath', type=str, default='/home/ray/bert/', help='Absolute path to dataset directory')
 parser.add_argument('--modelpath', type=str, default='/home/ray/bert/', help='Absolute path to model save location. Must be accessible to head node.')
 parser.add_argument('--logpath', type=str, default='/home/ray/bert/', help='Absolute path to log save location. Must be accessible to each worker node.')
+parser.add_argument('--tblogpath', type=str, default='/home/ray/bert/', help='Absolute path to tensorboard log location. Must be accessible to each worker node.')
 args = parser.parse_args()
 
 # Create the tensorboard log directory structure in advance, so that
 # any remote rsyncs won't try to fetch from a non-existent directory
-pathlib.Path(args.logpath).mkdir(parents=True, exist_ok=True)
-print(f"Logging tensorboard to {args.logpath}")
+#pathlib.Path(args.logpath).mkdir(parents=True, exist_ok=True)
+print(f"Logging tensorboard to {args.tblogpath}")
 
 ray.init(address="auto")
 
@@ -198,7 +200,8 @@ def train_func(config):
     dataset = config["data"]
 
     # Create a tensorboard writer. use args.logpath/jobid, if we have a jobid
-    tb_logpath = join(args.logpath, f'tb_gpu_{train.world_rank()}')
+    tfio = importlib.import_module("tensorflow_io")
+    tb_logpath = join(args.tblogpath, f'gpu_{train.world_rank()}/')
     writer = summary.create_file_writer(tb_logpath)
 
     # Model

--- a/guidebooks/ml/codeflare/training/bert/requirements.txt
+++ b/guidebooks/ml/codeflare/training/bert/requirements.txt
@@ -1,2 +1,3 @@
 torch
 tensorflow
+tensorflow-io

--- a/guidebooks/ml/codeflare/tuning/glue/choose-glue-data.md
+++ b/guidebooks/ml/codeflare/tuning/glue/choose-glue-data.md
@@ -1,0 +1,10 @@
+---
+imports:
+    - s3/choose/instance
+    - s3/choose/bucket
+    - path: s3/choose/_object.md
+      group: Choose your Glue Data File
+      env:
+          S3_SUFFIX: GLUEDATA
+---
+

--- a/guidebooks/ml/codeflare/tuning/glue/choose-model.md
+++ b/guidebooks/ml/codeflare/tuning/glue/choose-model.md
@@ -1,0 +1,10 @@
+---
+imports:
+    - s3/choose/instance
+    - s3/choose/bucket
+    - path: s3/choose/_object.md
+      group: Choose your Model File
+      env:
+          S3_SUFFIX: MODEL
+---
+

--- a/guidebooks/ml/codeflare/tuning/glue/index.md
+++ b/guidebooks/ml/codeflare/tuning/glue/index.md
@@ -3,8 +3,8 @@ imports:
     - ./overrides.md
     - ml/ray/start
     - util/jobid
-    - s3/choose/instance
-    - s3/choose/object
+    - ./choose-model.md
+    - ./choose-glue-data.md
 ---
 
 <!--    - ../../../../s3/create/kubernetes/secret-if-needed.md -->
@@ -40,7 +40,7 @@ export WANDB_DISABLED=true
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait -- -v -b ${S3_BUCKET} -m ${S3_OBJECT} -t WNLI -M -s 40 41 42 43
+exec: ray-submit --job-id ${JOB_ID} --no-wait -- -v -b ${S3_BUCKET} -m ${S3_OBJECTMODEL} -g ${S3_OBJECTGLUEDATA} -t WNLI -M -s 40 41 42 43
 ---
 --8<-- "./glue_benchmark.py"
 ```

--- a/guidebooks/ml/ray/hacks/openshift/uid-range.md
+++ b/guidebooks/ml/ray/hacks/openshift/uid-range.md
@@ -20,9 +20,9 @@ by default ([reference](https://access.redhat.com/solutions/2801791)).
     ```shell
     ---
     validate: |
-      [ $(kubectl get ns ${KUBE_NS} -o json | jq -r '.metadata.annotations."openshift.io/sa.scc.uid-range"') = "1000/10000" ]
+      [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ] && [ $(kubectl get ns ${KUBE_NS} --context ${KUBE_CONTEXT} -o json | jq -r '.metadata.annotations."openshift.io/sa.scc.uid-range"') = "1000/10000" ]
     ---
-    kubectl annotate namespace ${KUBE_NS} --overwrite openshift.io/sa.scc.uid-range=1000/10000
+    kubectl annotate namespace ${KUBE_NS} --context ${KUBE_CONTEXT} --overwrite openshift.io/sa.scc.uid-range=1000/10000
     ```
 
     Not changing the UID can cause permissions problems when the Ray

--- a/guidebooks/ml/ray/run/logs-in-s3.md
+++ b/guidebooks/ml/ray/run/logs-in-s3.md
@@ -1,0 +1,10 @@
+---
+imports:
+    - s3/choose/prereqs
+    - path: s3/choose/_bucket
+      group: S3 Bucket for Run Data
+      env:
+          S3_BUCKET_SUFFIX: RAYLOGS
+---
+
+# Store Ray Logs in S3

--- a/guidebooks/ml/ray/start/local.md
+++ b/guidebooks/ml/ray/start/local.md
@@ -1,7 +1,15 @@
 # Running Ray Locally
 
 This will install Ray on your laptop.
-    
+
+```shell
+export RAY_ADDRESS=http://127.0.0.1:8265
+```
+
+```shell
+export PIP_LOCAL=true
+```
+
 === "Intel"
     If you are running on x86/Intel hardware.
 
@@ -32,6 +40,3 @@ ray stop
 ray start --head
 ```
     
-```shell
-export RAY_ADDRESS=http://127.0.0.1:8265
-```

--- a/guidebooks/ml/tensorflow/tensorboard/run.md
+++ b/guidebooks/ml/tensorflow/tensorboard/run.md
@@ -12,7 +12,7 @@ export TB_OUT=$(mktemp)
 ```
 
 ```shell.async
-python3 -m tensorboard.main --window_title "Tensorboard ${JOB_NAME-${JOB_ID}}" --load_fast false --logdir "${TB_LOCAL_LOGDIR}" 2>&1 | tee "${TB_OUT}"
+python3 -m tensorboard.main --window_title "Tensorboard ${JOB_NAME-${JOB_ID}}" --logdir "${TB_LOGDIR}" 2>&1 | tee "${TB_OUT}"
 ```
 
 We'll need to capture the port, which we do via the `TB_OUT`

--- a/guidebooks/s3/choose/_bucket.md
+++ b/guidebooks/s3/choose/_bucket.md
@@ -1,0 +1,11 @@
+
+# Choose an S3 Bucket
+
+=== "expand([ -n "$MC_CONFIG_DIR" ] && mc -q --config-dir ${MC_CONFIG_DIR} ls s3 | awk '{print substr($NF, 1, length($NF) - 1)}', S3 Buckets)"
+    ```shell
+    export S3_BUCKET${S3_BUCKET_SUFFIX}="${choice}"
+    ```
+
+    ```shell
+    export S3_FILEPATH${S3_BUCKET_SUFFIX}="$S3_BUCKET${S3_BUCKET_SUFFIX}"
+    ```

--- a/guidebooks/s3/choose/_object.md
+++ b/guidebooks/s3/choose/_object.md
@@ -1,0 +1,9 @@
+
+=== "expand([ -n "$MC_CONFIG_DIR" ] && [ -n "$S3_FILEPATH${S3_BUCKET_SUFFIX}" ] && mc -q --config-dir ${MC_CONFIG_DIR} ls "s3/$S3_FILEPATH${S3_BUCKET_SUFFIX}" | awk '{print $NF}', S3 Objects)"
+    ```shell
+    export S3_OBJECT${S3_SUFFIX}="${choice}"
+    ```
+
+    ```shell
+    export S3_FILEPATH${S3_SUFFIX}="$S3_FILEPATH${S3_BUCKET_SUFFIX}/${choice}"
+    ```

--- a/guidebooks/s3/choose/bucket.md
+++ b/guidebooks/s3/choose/bucket.md
@@ -1,17 +1,2 @@
----
-imports:
-    - ./instance.md
-    - ../install/cli.md
-    - ../install/auth.md
----
-
-# Choose an S3 Bucket
-
-=== "expand([ -n "$MC_CONFIG_DIR" ] && mc -q --config-dir ${MC_CONFIG_DIR} ls s3 | awk '{print substr($NF, 1, length($NF) - 1)}', S3 Buckets)"
-    ```shell
-    export S3_BUCKET="${choice}"
-    ```
-
-    ```shell
-    export S3_FILEPATH="s3/${choice}"
-    ```
+--8<-- "./prereqs.md"
+--8<-- "./_bucket.md"

--- a/guidebooks/s3/choose/object.md
+++ b/guidebooks/s3/choose/object.md
@@ -1,15 +1,8 @@
 ---
 imports:
-    - ./bucket.md
+    - s3/choose/bucket
 ---
 
 # Choose an S3 Object
 
-=== "expand([ -n "$MC_CONFIG_DIR" ] && mc -q --config-dir ${MC_CONFIG_DIR} ls ${S3_FILEPATH} | awk '{print $NF}', S3 Objects)"
-    ```shell
-    export S3_OBJECT="${choice}"
-    ```
-
-    ```shell
-    export S3_FILEPATH="${S3_FILEPATH}/${choice}"
-    ```
+--8<-- "./_object.md"

--- a/guidebooks/s3/choose/prereqs.md
+++ b/guidebooks/s3/choose/prereqs.md
@@ -1,0 +1,6 @@
+---
+imports:
+    - s3/choose/instance
+    - s3/install/cli
+    - s3/install/auth
+---


### PR DESCRIPTION
This PR leverages that and related s3 improvements for
1) ml/codeflare/training/bert: store tensorboard events in s3
2) ml/codeflare/training/glue: choose glue-data and model

This PR also fixes aggressive validation checks in ml/ray/hcks/openshift/uid-range. We don't need to bother with potentially expensive kubectl operations if KUBE_CONTEXT and KUBE_NS are not defined. That guidebook was also not using KUBE_CONTEXT In its kubectl commands.