### PR TITLE
fix: optimize kubernetes validation tasks

### DIFF
--- a/guidebooks/kubernetes/choose/ns.md
+++ b/guidebooks/kubernetes/choose/ns.md
@@ -6,7 +6,7 @@ imports:
 
 # Target Kubernetes Namespace for Ray Cluster
 
-=== "expand(kubectl --context ${KUBE_CONTEXT} get ns -o name | grep -Ev 'openshift|kube-' | sed 's#namespace/##', Kubernetes namespaces)"
+=== "expand([ -z ${KUBE_CONTEXT} ] && exit 1 || kubectl --context ${KUBE_CONTEXT} get ns -o name | grep -Ev 'openshift|kube-' | sed 's#namespace/##', Kubernetes namespaces)"
     ```shell
     export KUBE_NS=${choice}
     ```

--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -23,7 +23,8 @@ kubectl get events --context ${KUBE_CONTEXT} -n ${KUBE_NS} --watch-only
 
 ```shell
 ---
-validate: X=$(kubectl --context ${KUBE_CONTEXT} get raycluster mycluster -n ${KUBE_NS} -o json); echo "$X" | grep -v 'No resources' && [ $(echo "$X" | jq '.spec.podTypes | .[] | select(.name=="rayWorkerType") | .podConfig.spec.containers[0].resources.requests.cpu') = ${NUM_CPUS-1} ]
+validate: |
+  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then X=$(kubectl --context ${KUBE_CONTEXT} get raycluster mycluster -n ${KUBE_NS} -o json); echo "$X" | grep -v 'No resources' && [ $(echo "$X" | jq '.spec.podTypes | .[] | select(.name=="rayWorkerType") | .podConfig.spec.containers[0].resources.requests.cpu') = ${NUM_CPUS-1} ]; fi
 ---
 echo "$(tput setaf 4)Cloning ray repo$(tput sgr0)"
 T=$(mktemp -d)


### PR DESCRIPTION
1) choosing a namespace; no need to do this if we haven't chosen a context
2) validating a previously started ray cluster in kube; no need to do this if we haven't chosen either a context or a namespace