### PR TITLE
fix: allow capturing of ray run logs to a local staging directory

### DIFF
--- a/guidebooks/ml/codeflare/job/log/init/s3.md
+++ b/guidebooks/ml/codeflare/job/log/init/s3.md
@@ -1,0 +1,62 @@
+---
+imports:
+    - ml/ray/run/logs-in-s3.md
+---
+
+```shell
+export CODEFLARE_STREAM_STAGE=$(mktemp -d)
+```
+
+```shell
+export CODEFLARE_LOGDIR="${S3_BUCKETRAYLOGS}/codeflare/${JOB_ID}"
+```
+
+```shell
+export CODEFLARE_LOGDIR_STAGE="${CODEFLARE_STREAM_STAGE}"
+```
+
+```shell
+echo ${JOB_ID} > ${CODEFLARE_LOGDIR_STAGE}/jobid.txt
+```
+
+```shell
+export CODEFLARE_LOGDIR_URI="s3://${S3_BUCKETRAYLOGS}/codeflare/${JOB_ID}"
+```
+
+```shell
+export CODEFLARE_LOGDIR_MC="s3/${S3_BUCKETRAYLOGS}/codeflare/${JOB_ID}"
+```
+
+<!-- mc --config-dir ${MC_CONFIG_DIR} pipe ${CODEFLARE_LOGDIR_MC}"-->
+
+```shell
+export STREAMCONSUMER_LOGS="${CODEFLARE_LOGDIR_STAGE}/logs/"
+```
+
+```shell
+mkdir -p "${CODEFLARE_LOGDIR_STAGE}/logs"
+```
+
+```shell
+export STREAMCONSUMER_EVENTS="${CODEFLARE_LOGDIR_STAGE}/events/"
+```
+
+```shell
+mkdir -p "${CODEFLARE_LOGDIR_STAGE}/events"
+```
+
+```shell
+export STREAMCONSUMER_RESOURCES="${CODEFLARE_LOGDIR_STAGE}/resources/"
+```
+
+```shell
+mkdir -p "${CODEFLARE_LOGDIR_STAGE}/resources"
+```
+
+```shell.async
+# i can't find a way to completely silence `mc cp`, and it emits progress to stdout (!!!), hence the > /dev/null
+while true; do
+  sleep 5
+  (cd ${CODEFLARE_LOGDIR_STAGE} && mc --config-dir ${MC_CONFIG_DIR} cp --recursive --quiet --preserve . ${CODEFLARE_LOGDIR_MC} > /dev/null)
+done
+```

--- a/guidebooks/ml/codeflare/training/bert/index.md
+++ b/guidebooks/ml/codeflare/training/bert/index.md
@@ -1,8 +1,8 @@
 ---
 imports:
-    - ml/ray/start
-    - ml/ray/run/logs-in-s3.md
     - util/jobid
+    - ml/codeflare/job/log/init/s3.md
+    - ml/ray/start
 ---
 
 # Distributed Language Modeling with BERT
@@ -27,7 +27,7 @@ export JOB_NAME=BERT
 ```
 
 ```shell
-export TB_LOGDIR="s3://${S3_BUCKETRAYLOGS}/codeflare/${JOB_ID}/"
+export TB_LOGDIR="${CODEFLARE_LOGDIR_URI}/tensorboard/"
 ```
 
 ```python

--- a/guidebooks/ml/codeflare/tuning/glue/choose-bucket.md
+++ b/guidebooks/ml/codeflare/tuning/glue/choose-bucket.md
@@ -1,0 +1,7 @@
+---
+imports:
+    - s3/choose/prereqs
+    - path: s3/choose/_bucket
+      group: Choose the bucket that contains your model and glue data
+---
+

--- a/guidebooks/ml/codeflare/tuning/glue/choose-glue-data.md
+++ b/guidebooks/ml/codeflare/tuning/glue/choose-glue-data.md
@@ -1,7 +1,6 @@
 ---
 imports:
-    - s3/choose/instance
-    - s3/choose/bucket
+    - ./choose-bucket.md
     - path: s3/choose/_object.md
       group: Choose your Glue Data File
       env:

--- a/guidebooks/ml/codeflare/tuning/glue/choose-model.md
+++ b/guidebooks/ml/codeflare/tuning/glue/choose-model.md
@@ -1,7 +1,6 @@
 ---
 imports:
-    - s3/choose/instance
-    - s3/choose/bucket
+    - ./choose-bucket.md
     - path: s3/choose/_object.md
       group: Choose your Model File
       env:

--- a/guidebooks/ml/codeflare/tuning/glue/index.md
+++ b/guidebooks/ml/codeflare/tuning/glue/index.md
@@ -1,7 +1,8 @@
 ---
 imports:
-    - ml/ray/start
     - util/jobid
+    - ml/codeflare/job/log/init/s3.md
+    - ml/ray/start
     - ./choose-model.md
     - ./choose-glue-data.md
 ---

--- a/guidebooks/ml/ray/run/gpu-utilization.sh
+++ b/guidebooks/ml/ray/run/gpu-utilization.sh
@@ -1,3 +1,3 @@
 kubectl get pod -l ${KUBE_POD_LABEL_SELECTOR} --context ${KUBE_CONTEXT} -n ${KUBE_NS} -o name \
     | xargs -I {} -n1 kubectl exec --context ${KUBE_CONTEXT} -n ${KUBE_NS} {} -- \
-            sh -c "nvidia-smi -q -d UTILIZATION -lms 5000 | awk -W interactive -F '           :' '/Gpu/ {print \"\n\033[31m\" \"Gpu Utilization:\", \$2 \"\033[0m\"}'"
+            sh -c "nvidia-smi -q -d UTILIZATION -lms 5000 | awk -W interactive -F '           :' '/Gpu/ {print \"\n\033[31m\" \"Gpu Utilization:\", \$2 \"\033[0m\"}'" | tee "${STREAMCONSUMER_RESOURCES}gpu.txt"

--- a/guidebooks/ml/ray/run/logs-websocat.md
+++ b/guidebooks/ml/ray/run/logs-websocat.md
@@ -1,0 +1,22 @@
+
+Using `websocat` is the easiest way @starpit can see to stream out the
+logs in a way that is compatible with `tee` or `>` or any other UNIX
+pipeline operators. See
+https://discuss.ray.io/t/ray-job-logs-follow-does-not-cooperate-with-unix-pipes/6489
+
+```shell.async
+if [ -n "${STREAMCONSUMER_LOGS}" ]; then
+    WS_ADDRESS=$(echo ${RAY_ADDRESS} | sed 's/^http/ws/')
+    websocat --no-line ${WS_ADDRESS}/api/jobs/${JOB_ID}/logs/tail | tee "${STREAMCONSUMER_LOGS}job.txt"
+fi
+```
+
+Oof, missing `ray job wait`... This is a simplisitic and wasteful way
+to do the same. See
+https://discuss.ray.io/t/feature-request-cli-command-ray-job-wait/6492
+
+```shell
+if [ -n "${STREAMCONSUMER_LOGS}" ]; then
+    ray job logs -f ${JOB_ID} >& /dev/null
+fi
+```

--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -1,3 +1,8 @@
+---
+imports:
+    - util/websocat
+---
+
 # Stream out Ray Job Logs
 
 --8<-- "./gpu-utilization.md"
@@ -13,5 +18,13 @@ while true; do if [ "$(ray job status ${JOB_ID} >& /dev/null && echo 1 || echo 0
 Then stream out the logs.
 
 ```shell
+echo "👉 $(tput setaf 6)Logs will be stored in this local staging directory: $(tput bold)${CODEFLARE_LOGDIR_STAGE}$(tput sgr0)"
+echo "👉 $(tput setaf 6)Logs will also be stored in s3: $(tput bold)${CODEFLARE_LOGDIR_URI}$(tput sgr0)"
+```
+
+```shell
 --8<-- "./logs.sh"
 ```
+
+--8<-- "./logs-websocat.md"
+

--- a/guidebooks/ml/ray/run/logs.sh
+++ b/guidebooks/ml/ray/run/logs.sh
@@ -1,1 +1,3 @@
-ray job logs -f ${JOB_ID} 2> /dev/null
+if [ -z "${STREAMCONSUMER_LOGS}" ]; then
+    ray job logs -f ${JOB_ID} 2> /dev/null
+fi

--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -16,7 +16,7 @@ This will install Ray on a Kubernetes context of your choosing.
 ### Stream out Events from the Ray Head Node
 
 ```shell.async
-kubectl get events --context ${KUBE_CONTEXT} -n ${KUBE_NS} --watch-only
+kubectl get events --context ${KUBE_CONTEXT} -n ${KUBE_NS} --watch-only | tee "${STREAMCONSUMER_EVENTS}kubernetes.txt"
 ```
 
 ### Use Helm to create the Ray Cluster

--- a/guidebooks/util/websocat.md
+++ b/guidebooks/util/websocat.md
@@ -1,0 +1,24 @@
+---
+validate: which websocat
+---
+
+# Websocat
+
+Netcat, curl and socat for [WebSockets](https://en.wikipedia.org/wiki/WebSocket).
+
+=== "MacOS"
+    ```shell
+    brew install websocat
+    ```
+    
+=== "Linux"
+    ```shell
+    echo "Automatic installation not yet supported. Please install via https://github.com/vi/websocat#installation"
+    exit 1
+    ```
+
+=== "Windows"
+    ```shell
+    echo "Automatic installation not yet supported. Please install via https://github.com/vi/websocat#installation"
+    exit 1
+    ```


### PR DESCRIPTION
note: ray job logs --follow does not coopeate with | tee, so we need to use websocat for now
https://discuss.ray.io/t/ray-job-logs-follow-does-not-cooperate-with-unix-pipes