### PR TITLE
fix: add --disable-usage-stats  to ray start command line

### DIFF
--- a/guidebooks/ml/ray/start/local.md
+++ b/guidebooks/ml/ray/start/local.md
@@ -37,6 +37,6 @@ export PIP_LOCAL=true
         
 ```shell
 ray stop
-ray start --head
+ray start --head --disable-usage-stats 
 ```
     


### PR DESCRIPTION
this came about in ray 1.13.0