### PR TITLE
fix: move a bash comment into a markdown sentence

### DIFF
--- a/guidebooks/ml/codeflare/job/log/init/s3.md
+++ b/guidebooks/ml/codeflare/job/log/init/s3.md
@@ -53,10 +53,11 @@ export STREAMCONSUMER_RESOURCES="${CODEFLARE_LOGDIR_STAGE}/resources/"
 mkdir -p "${CODEFLARE_LOGDIR_STAGE}/resources"
 ```
 
+I can't find a way to completely silence `mc cp`, and it emits progress to stdout, hence the `> /dev/null`
+
 ```shell.async
-# i can't find a way to completely silence `mc cp`, and it emits progress to stdout (!!!), hence the > /dev/null
 while true; do
-  sleep 5
+  sleep ${S3_SYNC_INTERVAL-10}
   (cd ${CODEFLARE_LOGDIR_STAGE} && mc --config-dir ${MC_CONFIG_DIR} cp --recursive --quiet --preserve . ${CODEFLARE_LOGDIR_MC} > /dev/null)
 done
 ```


### PR DESCRIPTION
this avoids showing some commentary in a madwizard run that is only relevant to the guidebook developer