### PR TITLE
fix: s3/choose/object prematurely executes expensive ListObjects api …

### DIFF
--- a/guidebooks/s3/choose/_object.md
+++ b/guidebooks/s3/choose/_object.md
@@ -1,5 +1,5 @@
 
-=== "expand([ -n "$MC_CONFIG_DIR" ] && [ -n "$S3_FILEPATH${S3_BUCKET_SUFFIX}" ] && mc -q --config-dir ${MC_CONFIG_DIR} ls "s3/$S3_FILEPATH${S3_BUCKET_SUFFIX}" | awk '{print $NF}', S3 Objects)"
+=== "expand([ -n "$MC_CONFIG_DIR" ] && [ -n "$S3_FILEPATH" ] && [ -n "$S3_FILEPATH${S3_BUCKET_SUFFIX}" ] && mc -q --config-dir ${MC_CONFIG_DIR} ls "s3/$S3_FILEPATH${S3_BUCKET_SUFFIX}" | awk '{print $NF}', S3 Objects)"
     ```shell
     export S3_OBJECT${S3_SUFFIX}="${choice}"
     ```


### PR DESCRIPTION
…call

We invoke the ListObjects api before the user has identified a bucket.