### PR TITLE
feat: ml/ray/run/logs should track node utilization stats

### DIFF
--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -5,6 +5,7 @@ imports:
 
 # Stream out Ray Job Logs
 
+--8<-- "./node-stats.md"
 --8<-- "./gpu-utilization.md"
 
 ## Stream Ray Job Logs

--- a/guidebooks/ml/ray/run/node-stats.md
+++ b/guidebooks/ml/ray/run/node-stats.md
@@ -1,0 +1,21 @@
+# Sample Retrieve Kubernetes Node Statistics
+
+This guidebook will emit a stream of samples of the form:
+
+```
+NAME                           GPUCapacity   GPUFree   CPUCapacity   CPUFree   MemoryCapacity   MemoryFree   Type
+ip-10-0-131-199.ec2.internal   <none>        <none>    2             1500m     8149576Ki        6998600Ki    m4.large
+ip-10-0-131-59.ec2.internal    <none>        <none>    4             3500m     16407104Ki       15256128Ki   m4.xlarge
+ip-10-0-138-205.ec2.internal   1             1         8             7500m     62855724Ki       61704748Ki   p3.2xlarge
+ip-10-0-141-246.ec2.internal   1             1         8             7500m     62855724Ki       61704748Ki   p3.2xlarge
+ip-10-0-142-209.ec2.internal   1             1         8             7500m     62855724Ki       61704748Ki   p3.2xlarge
+ip-10-0-142-49.ec2.internal    1             1         8             7500m     62855724Ki       61704748Ki   p3.2xlarge
+ip-10-0-154-249.ec2.internal   <none>        <none>    2             1500m     8149576Ki        6998600Ki    m4.large
+ip-10-0-158-5.ec2.internal     <none>        <none>    4             3500m     16407108Ki       15256132Ki   m4.xlarge
+ip-10-0-167-175.ec2.internal   <none>        <none>    2             1500m     8149572Ki        6998596Ki    m4.large
+ip-10-0-169-105.ec2.internal   <none>        <none>    4             3500m     16407108Ki       15256132Ki   m4.xlarge
+```
+
+```shell.async
+--8<-- "./node-stats.sh"
+```

--- a/guidebooks/ml/ray/run/node-stats.sh
+++ b/guidebooks/ml/ray/run/node-stats.sh
@@ -1,0 +1,8 @@
+while true; do
+    sleep 10
+
+    kubectl get node --context ${KUBE_CONTEXT} --watch \
+            -o custom-columns='NAME:.metadata.name,GPUCap:.status.capacity.nvidia\.com/gpu,GPUFree:.status.allocatable.nvidia\.com/gpu,CPUCap:.status.capacity.cpu,CPUFree:.status.allocatable.cpu,MemCap:.status.capacity.memory,MemFree:.status.allocatable.memory,DiskCap:.status.capacity.ephemeral-storage,DiskFree:.status.allocatable.ephemeral-storage,Type:.metadata.labels.beta\.kubernetes\.io/instance-type' \
+        | while read line ; do echo -e "$(date +"%Y-%m-%d %H:%M:%S")\t $line" ; done \
+              >> "${STREAMCONSUMER_RESOURCES}node-stats.txt"
+done


### PR DESCRIPTION
a bit ugly, with the timestamp at the beginning, but i couldn't see a way to do this more gracefully -- i.e. integrate a timestamp with the underlying info that comes from `kubectl`. Using `kubectl get node --watch` would only give us updates on change to the underlying resource. Whereas we want to track this as MemFree, etc. the Free stats change.

```
2022-06-20 19:46:13	 NAME                           GPUCap   GPUFree   CPUCap   CPUFree   MemCap       MemFree      DiskCap       DiskFree       Type
2022-06-20 19:46:13	 ip-10-0-131-199.ec2.internal   <none>   <none>    2        1500m     8149576Ki    6998600Ki    125293548Ki   115470533646   m4.large
2022-06-20 19:46:13	 ip-10-0-131-59.ec2.internal    <none>   <none>    4        3500m     16407104Ki   15256128Ki   125293548Ki   115470533646   m4.xlarge
2022-06-20 19:46:13	 ip-10-0-138-205.ec2.internal   1        1         8        7500m     62855724Ki   61704748Ki   125293548Ki   115470533646   p3.2xlarge
2022-06-20 19:46:13	 ip-10-0-141-246.ec2.internal   1        1         8        7500m     62855724Ki   61704748Ki   125293548Ki   115470533646   p3.2xlarge
2022-06-20 19:46:13	 ip-10-0-142-209.ec2.internal   1        1         8        7500m     62855724Ki   61704748Ki   125293548Ki   115470533646   p3.2xlarge
2022-06-20 19:46:13	 ip-10-0-142-49.ec2.internal    1        1         8        7500m     62855724Ki   61704748Ki   125293548Ki   115470533646   p3.2xlarge
2022-06-20 19:46:13	 ip-10-0-154-249.ec2.internal   <none>   <none>    2        1500m     8149576Ki    6998600Ki    125293548Ki   115470533646   m4.large
2022-06-20 19:46:13	 ip-10-0-158-5.ec2.internal     <none>   <none>    4        3500m     16407108Ki   15256132Ki   125293548Ki   115470533646   m4.xlarge
2022-06-20 19:46:13	 ip-10-0-167-175.ec2.internal   <none>   <none>    2        1500m     8149572Ki    6998596Ki    125293548Ki   115470533646   m4.large
2022-06-20 19:46:13	 ip-10-0-169-105.ec2.internal   <none>   <none>    4        3500m     16407108Ki   15256132Ki   125293548Ki   115470533646   m4.xlarge
2022-06-20 19:46:15	 ip-10-0-141-246.ec2.internal   1        1         8        7500m     62855724Ki   61704748Ki   125293548Ki   115470533646   p3.2xlarge
```