### PR TITLE
feat: update ml/ray/run/node-stats syntax to use ISO dates

### DIFF
--- a/guidebooks/ml/ray/run/node-stats.sh
+++ b/guidebooks/ml/ray/run/node-stats.sh
@@ -1,8 +1,9 @@
 while true; do
     sleep 10
 
-    kubectl get node --context ${KUBE_CONTEXT} --watch \
+    echo -e "NodeStats $(date -Iseconds)" >> "${STREAMCONSUMER_RESOURCES}node-stats.txt"
+    kubectl get node --context ${KUBE_CONTEXT} \
             -o custom-columns='NAME:.metadata.name,GPUCap:.status.capacity.nvidia\.com/gpu,GPUFree:.status.allocatable.nvidia\.com/gpu,CPUCap:.status.capacity.cpu,CPUFree:.status.allocatable.cpu,MemCap:.status.capacity.memory,MemFree:.status.allocatable.memory,DiskCap:.status.capacity.ephemeral-storage,DiskFree:.status.allocatable.ephemeral-storage,Type:.metadata.labels.beta\.kubernetes\.io/instance-type' \
-        | while read line ; do echo -e "$(date +"%Y-%m-%d %H:%M:%S")\t $line" ; done \
-              >> "${STREAMCONSUMER_RESOURCES}node-stats.txt"
+            >> "${STREAMCONSUMER_RESOURCES}node-stats.txt"
+    echo >> "${STREAMCONSUMER_RESOURCES}node-stats.txt"
 done


### PR DESCRIPTION
1) use ISO timestamps
2) don't repeat the timestamp for each row, i think this will be too hard to parse

```
NodeStats 2022-06-20T20:41:53-04:00
NAME             GPUCap   GPUFree   CPUCap   CPUFree   MemCap       MemFree      DiskCap       DiskFree      Type
10.186.206.229   <none>   <none>    4        3910m     16260832Ki   13484768Ki   103078840Ki   94369515442   b3c.4x16.encrypted
10.186.206.230   <none>   <none>    4        3910m     16253388Ki   13477324Ki   103078840Ki   94369515442   b3c.4x16.encrypted

NodeStats 2022-06-20T20:41:53-04:00
NAME             GPUCap   GPUFree   CPUCap   CPUFree   MemCap       MemFree      DiskCap       DiskFree      Type
10.186.206.229   <none>   <none>    4        3910m     16260832Ki   13484768Ki   103078840Ki   94369515442   b3c.4x16.encrypted
10.186.206.230   <none>   <none>    4        3910m     16253388Ki   13477324Ki   103078840Ki   94369515442   b3c.4x16.encrypted
```