### PR TITLE
feat: add pod statistics ml/ray/run/pod-stats.md

### DIFF
--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -5,6 +5,7 @@ imports:
 
 # Stream out Ray Job Logs
 
+--8<-- "./pod-stats.md"
 --8<-- "./node-stats.md"
 --8<-- "./gpu-utilization.md"
 

--- a/guidebooks/ml/ray/run/node-stats.sh
+++ b/guidebooks/ml/ray/run/node-stats.sh
@@ -1,7 +1,7 @@
 while true; do
     sleep 10
 
-    echo -e "NodeStats $(date -Iseconds)" >> "${STREAMCONSUMER_RESOURCES}node-stats.txt"
+    echo -e "Sample $(date -Iseconds)" >> "${STREAMCONSUMER_RESOURCES}node-stats.txt"
     kubectl get node --context ${KUBE_CONTEXT} \
             -o custom-columns='NAME:.metadata.name,GPUCap:.status.capacity.nvidia\.com/gpu,GPUFree:.status.allocatable.nvidia\.com/gpu,CPUCap:.status.capacity.cpu,CPUFree:.status.allocatable.cpu,MemCap:.status.capacity.memory,MemFree:.status.allocatable.memory,DiskCap:.status.capacity.ephemeral-storage,DiskFree:.status.allocatable.ephemeral-storage,Type:.metadata.labels.beta\.kubernetes\.io/instance-type' \
             >> "${STREAMCONSUMER_RESOURCES}node-stats.txt"

--- a/guidebooks/ml/ray/run/pod-stats.md
+++ b/guidebooks/ml/ray/run/pod-stats.md
@@ -1,0 +1,17 @@
+# Sample Retrieve Kubernetes Pod Statistics
+
+This guidebook will emit a stream of samples of the form:
+
+```
+Sample 2022-06-21T08:19:54-04:00
+NAME                              GPUReq   CPUReq   MemReq
+mycluster-ray-worker-type-np2vr   1        1        32Gi
+
+Sample 2022-06-21T08:19:54-04:05
+NAME                              GPUReq   CPUReq   MemReq
+mycluster-ray-worker-type-np2vr   1        1        32Gi
+```
+
+```shell.async
+--8<-- "./pod-stats.sh"
+```

--- a/guidebooks/ml/ray/run/pod-stats.sh
+++ b/guidebooks/ml/ray/run/pod-stats.sh
@@ -1,0 +1,10 @@
+while true; do
+    sleep 10
+
+    echo -e "Sample $(date -Iseconds)" >> "${STREAMCONSUMER_RESOURCES}pod-stats.txt"
+    kubectl get pod --context ${KUBE_CONTEXT} -n ${KUBE_NS} \
+            -l ${KUBE_POD_LABEL_SELECTOR} \
+            -o custom-columns='NAME:.metadata.name,GPUReq:.spec.containers[0].resources.requests.nvidia\.com/gpu,CPUReq:.spec.containers[0].resources.requests.cpu,MemReq:.spec.containers[0].resources.requests.memory' \
+            >> "${STREAMCONSUMER_RESOURCES}pod-stats.txt"
+    echo >> "${STREAMCONSUMER_RESOURCES}pod-stats.txt"
+done


### PR DESCRIPTION
This PR also updates node-stats.sh to use "Sample <timestamp>" as the header, rather than "NodeStats <timestamp>", and the pod-stats.sh stream uses the same Sample header. Hopefully this should ease parsing a bit.