### PR TITLE
fix: kubernetes/context should not set global kube context

### DIFF
--- a/guidebooks/kubernetes/context.md
+++ b/guidebooks/kubernetes/context.md
@@ -7,9 +7,5 @@ imports:
 
 === "expand(kubectl config get-contexts -o name, Kubernetes contexts)"
     ```shell
-    kubectl config use-context "${choice}"
-    ```
-    
-    ```shell
     export KUBE_CONTEXT="${choice}"
     ```


### PR DESCRIPTION
we can avoid setting global state, because madwizard can flow through state just for a given run