### PR TITLE
fix: clean up ml/codeflare titles and descriptions

### DIFF
--- a/guidebooks/ml/codeflare/index.md
+++ b/guidebooks/ml/codeflare/index.md
@@ -1,4 +1,11 @@
-# Codeflare Applications
+# Project Codeflare
+
+Welcome to
+[CodeFlare](https://research.ibm.com/blog/codeflare-ml-experiments),
+tooling to drastically reduce time to set up, run, and scale
+machine-learning logic.
+
+## What kind of application do you want to run?
 
 === "Training"
     --8<-- "./training"

--- a/guidebooks/ml/codeflare/training/index.md
+++ b/guidebooks/ml/codeflare/training/index.md
@@ -5,5 +5,7 @@ The process of training an ML model involves providing an ML algorithm
 from. The term ML model refers to the model artifact that is created
 by the training process.
 
+## Which training application do you want to run?
+
 === "BERT"
     --8<-- "./bert"

--- a/guidebooks/ml/codeflare/tuning/index.md
+++ b/guidebooks/ml/codeflare/tuning/index.md
@@ -1,8 +1,10 @@
 # Codeflare Fine-Tuning Applications
 
-Finetuning means taking weights of a trained neural network and use it
-as initialization for a new model being trained on data from the same
-domain
+Fine tuning means taking weights of a trained neural network and use
+it as initialization for a new model being trained on data from the
+same domain.
+
+## Which fine-tuning application do you want to run?
 
 === "GLUE"
     --8<-- "./glue"


### PR DESCRIPTION
Nothing in the code blocks, just in the titles and expositions.