### PR TITLE
fix: ml/ray/start/kubernetes via helm fixes

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -24,7 +24,11 @@ kubectl get events --context ${KUBE_CONTEXT} -n ${KUBE_NS} --watch-only | tee "$
 This defines the base docker image we will use for the ray head and worker nodes.
 
 ```shell
-export RAY_IMAGE=${RAY_IMAGE-$([ $NUM_GPUS = 0 ] && echo rayproject/ray:1.12.2-py37 || echo rayproject/ray-ml:1.12.2-py37-gpu)}
+export RAY_OPERATOR_IMAGE=${RAY_OPERATOR_IMAGE-rayproject/ray:1.13.0-py37}
+```
+
+```shell
+export RAY_IMAGE=${RAY_IMAGE-$([ $NUM_GPUS = 0 ] && echo rayproject/ray:1.13.0-py37 || echo rayproject/ray-ml:1.13.0-py37-gpu)}
 ```
 
 A staging directory for the clone of the Ray Helm chart.

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.md
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.md
@@ -11,8 +11,9 @@ git clone --filter=tree:0 --depth 1 --sparse https://github.com/ray-project/ray.
     git sparse-checkout init --cone >& /dev/null && \
     git sparse-checkout set deploy/charts/ray >& /dev/null
 
-echo "$(tput setaf 4)Creating ray cluster num_cpus=$(tput setaf 5)${NUM_CPUS-1} $(tput setaf 4)num_gpus=$(tput setaf 5)${NUM_GPUS-1} $(tput setaf 4)head_memory=$(tput setaf 5)${HEAD_MEMORY-1Gi} $(tput setaf 4)worker_memory=$(tput setaf 5)${WORKER_MEMORY-1Gi} $(tput setaf 4)minWorkers=$(tput setaf 5)${MIN_WORKERS-2} $(tput setaf 4)maxWorkers=$(tput setaf 5)${MAX_WORKERS-3} $(tput setaf 4)image=$(tput setaf 5)${RAY_IMAGE} $(tput setaf 4)context=$(tput setaf 5)${KUBE_CONTEXT} $(tput setaf 4)namespace=$(tput setaf 5)${KUBE_NS}$(tput sgr0)"
+echo "$(tput setaf 4)Creating ray cluster num_cpus=$(tput setaf 5)${NUM_CPUS-1} $(tput setaf 4)num_gpus=$(tput setaf 5)${NUM_GPUS-1} $(tput setaf 4)head_memory=$(tput setaf 5)${HEAD_MEMORY-1Gi} $(tput setaf 4)worker_memory=$(tput setaf 5)${WORKER_MEMORY-1Gi} $(tput setaf 4)minWorkers=$(tput setaf 5)${MIN_WORKERS-2} $(tput setaf 4)maxWorkers=$(tput setaf 5)${MAX_WORKERS-3} $(tput setaf 4)image=$(tput setaf 5)${RAY_IMAGE} $(tput setaf 4)operatorImage=$(tput setaf 5)${RAY_OPERATOR_IMAGE} $(tput setaf 4)context=$(tput setaf 5)${KUBE_CONTEXT} $(tput setaf 4)namespace=$(tput setaf 5)${KUBE_NS}$(tput sgr0)"
 
-cd $HELM_CLONE_TEMPDIR/ray
-helm -n ${KUBE_NS} upgrade --install --wait --timeout 30m ${RAY_KUBE_CLUSTER_NAME} --create-namespace deploy/charts/ray --set podTypes.rayWorkerType.CPU=${NUM_CPUS-1} --set podTypes.rayWorkerType.GPU=${NUM_GPUS-1} --set podTypes.rayHeadType.memory=${HEAD_MEMORY-1Gi} --set podTypes.rayWorkerType.memory=${WORKER_MEMORY-1Gi} --set podTypes.rayWorkerType.minWorkers=${MIN_WORKERS-2} --set podTypes.rayWorkerType.maxWorkers=${MAX_WORKERS-3} --set image=${RAY_IMAGE}
+sed -i '' -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' deploy/charts/ray/templates/*.yaml
+
+helm --kube-context ${KUBE_CONTEXT} -n ${KUBE_NS} upgrade --install --wait --timeout 30m ${RAY_KUBE_CLUSTER_NAME} --create-namespace deploy/charts/ray --set podTypes.rayWorkerType.CPU=${NUM_CPUS-1} --set podTypes.rayWorkerType.GPU=${NUM_GPUS-1} --set podTypes.rayHeadType.memory=${HEAD_MEMORY-1Gi} --set podTypes.rayWorkerType.memory=${WORKER_MEMORY-1Gi} --set podTypes.rayWorkerType.minWorkers=${MIN_WORKERS-2} --set podTypes.rayWorkerType.maxWorkers=${MAX_WORKERS-3} --set image=${RAY_IMAGE} --set operatorImage=${RAY_OPERATOR_IMAGE}
 ```


### PR DESCRIPTION
1. the helm upgrade command was not using the KUBE_CONTEXT variable
2. update to use IfNotPresent image pull policy
3. allow for a different operatorImage from head/worker images
4. upgrade from ray 1.12.2 to 1.13.0 for default base image