### PR TITLE
feat: update some of the ml/ray/run log aggregators to support not teeing to the console

### DIFF
--- a/guidebooks/ml/ray/run/gpu-utilization.sh
+++ b/guidebooks/ml/ray/run/gpu-utilization.sh
@@ -1,6 +1,13 @@
 if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
 
-kubectl get pod -l ${KUBE_POD_LABEL_SELECTOR} --context ${KUBE_CONTEXT} -n ${KUBE_NS} -o name \
-    | xargs ${REPLSIZE} -P128 -I {} -n1 \
+if [ -z "$QUIET_CONSOLE" ]; then
+    kubectl get pod -l ${KUBE_POD_LABEL_SELECTOR} --context ${KUBE_CONTEXT} -n ${KUBE_NS} -o name \
+        | xargs ${REPLSIZE} -P128 -I {} -n1 \
             sh -c "sleep 0.\$(shuf -i 100-2000 -n1); kubectl exec --context ${KUBE_CONTEXT} -n ${KUBE_NS} {} -- sh -c \"nvidia-smi --query-gpu=timestamp,utilization.gpu,utilization.memory,memory.total,temperature.gpu,name --format=csv,noheader -l 2 | awk -Winteractive -v pod=\\\$(hostname) -F, '{printf \\\"\n\033[31;1m%s \033[0;31mGPUType\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$6, pod, \\\$1; printf \\\"\033[31;1m%s \033[0;31mUtilization.GPU\t\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$2, pod, \\\$1; printf \\\"\033[31;1m%s \033[0;31mUtilization.Memory\t\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$3, pod, \\\$1; printf \\\"\033[31;1m%s \033[0;31mMemory.Total\t\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$4, pod, \\\$1; printf \\\"\033[31;1m%s \033[0;31mTemperature.GPU\t\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$5, pod, \\\$1; }'\"" \
-    | tee "${STREAMCONSUMER_RESOURCES}gpu.txt"
+            | tee "${STREAMCONSUMER_RESOURCES}gpu.txt"
+else
+    kubectl get pod -l ${KUBE_POD_LABEL_SELECTOR} --context ${KUBE_CONTEXT} -n ${KUBE_NS} -o name \
+        | xargs ${REPLSIZE} -P128 -I {} -n1 \
+            sh -c "sleep 0.\$(shuf -i 100-2000 -n1); kubectl exec --context ${KUBE_CONTEXT} -n ${KUBE_NS} {} -- sh -c \"nvidia-smi --query-gpu=timestamp,utilization.gpu,utilization.memory,memory.total,temperature.gpu,name --format=csv,noheader -l 2 | awk -Winteractive -v pod=\\\$(hostname) -F, '{printf \\\"\n\033[31;1m%s \033[0;31mGPUType\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$6, pod, \\\$1; printf \\\"\033[31;1m%s \033[0;31mUtilization.GPU\t\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$2, pod, \\\$1; printf \\\"\033[31;1m%s \033[0;31mUtilization.Memory\t\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$3, pod, \\\$1; printf \\\"\033[31;1m%s \033[0;31mMemory.Total\t\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$4, pod, \\\$1; printf \\\"\033[31;1m%s \033[0;31mTemperature.GPU\t\t\t\033[0;2m%s %s\033[0m\n\\\", \\\$5, pod, \\\$1; }'\"" \
+            > "${STREAMCONSUMER_RESOURCES}gpu.txt"
+fi

--- a/guidebooks/ml/ray/run/logs-websocat.md
+++ b/guidebooks/ml/ray/run/logs-websocat.md
@@ -7,7 +7,12 @@ https://discuss.ray.io/t/ray-job-logs-follow-does-not-cooperate-with-unix-pipes/
 ```shell.async
 if [ -n "${STREAMCONSUMER_LOGS}" ]; then
     WS_ADDRESS=$(echo ${RAY_ADDRESS} | sed 's/^http/ws/')
-    websocat --no-line ${WS_ADDRESS}/api/jobs/${JOB_ID}/logs/tail | tee "${STREAMCONSUMER_LOGS}job.txt"
+
+    if [ -z "$QUIET_CONSOLE" ]; then
+        websocat --no-line ${WS_ADDRESS}/api/jobs/${JOB_ID}/logs/tail | tee "${STREAMCONSUMER_LOGS}job.txt"
+    else
+        websocat -B 524288 --no-line ${WS_ADDRESS}/api/jobs/${JOB_ID}/logs/tail > "${STREAMCONSUMER_LOGS}job.txt"
+    fi
 fi
 ```
 
@@ -17,6 +22,8 @@ https://discuss.ray.io/t/feature-request-cli-command-ray-job-wait/6492
 
 ```shell
 if [ -n "${STREAMCONSUMER_LOGS}" ]; then
-    ray job logs -f ${JOB_ID} >& /dev/null
+    if [ -z "$NO_WAIT" ]; then
+        ray job logs -f ${JOB_ID} >& /dev/null
+    fi
 fi
 ```

--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -35,9 +35,26 @@ if [ -n "${LOGDIR_STAGE}" ]; then
 fi
 ```
 
+Only one of these two will operate --- if you look into each, you will
+see that they are guarded either by `$STREAMCONSUMER_LOGS` not being
+defined, or being defined, respectively. The former case streams just
+to the console. This can use `ray job logs -f` directly. The latter
+case handles streaming the output somewhere, such as to a file (and
+possibly to the console, too, via `tee`).
+
+It turns out that the `ray` CLI does some sort of batching that makes
+consuming streaming output from that file "batchy". Instead, we use
+[`websocat`](https://github.com/vi/websocat) to talk directly to the
+Ray API; for log following, this is a websocket protocol, hence the
+need for an additional tool. Sigh.
+
+### Logs just to console
+
 ```shell
 --8<-- "./logs.sh"
 ```
+
+### Logs to a file (and possibly the console, too)
 
 --8<-- "./logs-websocat.md"
 


### PR DESCRIPTION

This PR adds:

- QUIET_CONSOLE: don't emit to the console, just direct to files
- NO_WAIT: don't wait for the job to finish