### PR TITLE
feat: new ml/codeflare top-level guidebook

### DIFF
--- a/guidebooks/ml/codeflare/index.md
+++ b/guidebooks/ml/codeflare/index.md
@@ -1,14 +1,22 @@
 # Project Codeflare
 
-Welcome to
-[CodeFlare](https://research.ibm.com/blog/codeflare-ml-experiments),
-tooling to drastically reduce time to set up, run, and scale
-machine-learning logic.
+--8<-- "./welcome.md"
 
-## What kind of application do you want to run?
+## What do you want to do today?
 
-=== "Training"
-    --8<-- "./training"
+=== "Start a new Run"
+    --8<-- "./run.md"
+    
+=== "Connect Dashboard to an existing Run"
+    I would like to visualize the resource consumption, status, and logs of a run in progress.
+    ```shell
+    codeflare db -a
+    ```
 
-=== "Fine Tuning"
-    --8<-- "./tuning"
+=== "Boot up a Cloud Computer"
+    I want to configure and boot up a Cloud Computer.
+    :import{ml/ray/start/kubernetes}
+
+=== "Shut down a Cloud Computer"
+    I want to save money, and take one of my Cloud Computers offline.
+    :import{ml/ray/stop/kubernetes}

--- a/guidebooks/ml/codeflare/run.md
+++ b/guidebooks/ml/codeflare/run.md
@@ -1,0 +1,11 @@
+# Project Codeflare: Run a Job
+
+I would like to configure and fire off a run.
+
+## What kind of application do you want to run?
+
+=== "Training"
+    --8<-- "./training"
+
+=== "Fine Tuning"
+    --8<-- "./tuning"

--- a/guidebooks/ml/codeflare/welcome.md
+++ b/guidebooks/ml/codeflare/welcome.md
@@ -1,0 +1,4 @@
+Welcome to
+[CodeFlare](https://research.ibm.com/blog/codeflare-ml-experiments),
+tooling to drastically reduce time to set up, run, and scale
+machine-learning logic.


### PR DESCRIPTION
Previously, the ml/codeflare/index.md guidebook was about running a job. This PR renames that to run.md, and slots in a new index.md where running a job is just one of several options (attach dashboard, ...)