### PR TITLE
feat: rename to use kui_ prefix

### DIFF
--- a/guidebooks/ml/ray/aggregator/setup.md
+++ b/guidebooks/ml/ray/aggregator/setup.md
@@ -9,7 +9,7 @@ imports:
 Set up some variables that are dependently on the selected run.
 
 ```shell
-export JOB_ENV=$(curl $RAY_ADDRESS/api/jobs/$JOB_ID | jq -cr '.runtime_env.env_vars')
+export JOB_ENV=$(curl $KUI_RAY_ADDRESS/api/jobs/$JOB_ID | jq -cr '.runtime_env.env_vars')
 ```
 
 ```shell

--- a/guidebooks/ml/ray/cluster/kubernetes.md
+++ b/guidebooks/ml/ray/cluster/kubernetes.md
@@ -15,8 +15,8 @@ export RAY_KUBE_PORT=${RAY_KUBE_PORT-$(shuf -i 8266-9999 -n1)}
 ## The URL to use for `ray` operations
 
 Note: set this after bringing up the port-forward, because the
-RAY_ADDRESS is not valid until the port forward is up.
+KUI_RAY_ADDRESS is not valid until the port forward is up.
 
 ```shell
-export RAY_ADDRESS="http://127.0.0.1:$RAY_KUBE_PORT"
+export KUI_RAY_ADDRESS="http://127.0.0.1:$RAY_KUBE_PORT"
 ```

--- a/guidebooks/ml/ray/cluster/local.md
+++ b/guidebooks/ml/ray/cluster/local.md
@@ -7,5 +7,5 @@ export RAY_KUBE_PORT=${RAY_KUBE_PORT-8265}
 ```
 
 ```shell
-export RAY_ADDRESS=http://127.0.0.1:${RAY_KUBE_PORT}
+export KUI_RAY_ADDRESS=http://127.0.0.1:${RAY_KUBE_PORT}
 ```

--- a/guidebooks/ml/ray/run/choose.md
+++ b/guidebooks/ml/ray/run/choose.md
@@ -6,7 +6,7 @@ imports:
 
 # Choose a Ray Run
 
-=== "expand([ -n \"$RAY_ADDRESS\" ] && curl $RAY_ADDRESS/api/jobs/ | jq -r 'to_entries | sort_by(.value.start_time) | reverse | .[] | \"\\(.key) \\(.value.status) \\(.value.start_time / 1000 | strflocaltime(\"%Y-%m-%dT%H:%M:%S\")) \\(.value.entrypoint)\"' | sed -E 's/python3 ([^[:space:]])+ //g' | awk '{a=$1;b=$2;c=$3; $1=\"\";$2=\"\";$3=\"\"; print a, \"\033[0;36m\" c, \"\033[0;1;33m\" b \"\033[0;2m\" $0 \"\033[0m\"}', Ray Runs)"
+=== "expand([ -n \"$KUI_RAY_ADDRESS\" ] && curl $KUI_RAY_ADDRESS/api/jobs/ | jq -r 'to_entries | sort_by(.value.start_time) | reverse | .[] | \"\\(.key) \\(.value.status) \\(.value.start_time / 1000 | strflocaltime(\"%Y-%m-%dT%H:%M:%S\")) \\(.value.entrypoint)\"' | sed -E 's/python3 ([^[:space:]])+ //g' | awk '{a=$1;b=$2;c=$3; $1=\"\";$2=\"\";$3=\"\"; print a, \"\033[0;36m\" c, \"\033[0;1;33m\" b \"\033[0;2m\" $0 \"\033[0m\"}', Ray Runs)"
     ```shell
     export JOB_ID=$(echo "$choice" | awk '{print $1}')
     ```

--- a/guidebooks/ml/ray/run/job-definition.md
+++ b/guidebooks/ml/ray/run/job-definition.md
@@ -11,13 +11,13 @@ Let's capture parameters of the job. This will include, for example,
 the Ray `runtime_env`.
 
 ```shell.async
-curl -s $RAY_ADDRESS/api/jobs/$JOB_ID > "${LOGDIR_STAGE}/ray-job-definition.json"
+curl -s $KUI_RAY_ADDRESS/api/jobs/$JOB_ID > "${LOGDIR_STAGE}/ray-job-definition.json"
 INPUT=$(cat "${LOGDIR_STAGE}/ray-job-definition.json" | jq -r .entrypoint | awk '{print $2}')
 PKGDIR=$(cat "${LOGDIR_STAGE}/ray-job-definition.json" | jq -r .runtime_env.working_dir | sed 's#gcs://##' | sed 's/\.zip//')
 kubectl exec --context ${KUBE_CONTEXT} -n ${KUBE_NS} ${RAY_HEAD_POD} -- cat /tmp/ray/session_latest/runtime_resources/working_dir_files/${PKGDIR}/${INPUT} >> "${LOGDIR_STAGE}/source.py"
 
 while true; do
-    curl -s $RAY_ADDRESS/api/jobs/$JOB_ID > "${LOGDIR_STAGE}/ray-job-definition.json"
+    curl -s $KUI_RAY_ADDRESS/api/jobs/$JOB_ID > "${LOGDIR_STAGE}/ray-job-definition.json"
     sleep 10
 done
 ```

--- a/guidebooks/ml/ray/run/logs-websocat.md
+++ b/guidebooks/ml/ray/run/logs-websocat.md
@@ -6,7 +6,7 @@ https://discuss.ray.io/t/ray-job-logs-follow-does-not-cooperate-with-unix-pipes/
 
 ```shell.async
 if [ -n "${STREAMCONSUMER_LOGS}" ]; then
-    WS_ADDRESS=$(echo ${RAY_ADDRESS} | sed 's/^http/ws/')
+    WS_ADDRESS=$(echo ${KUI_RAY_ADDRESS} | sed 's/^http/ws/')
 
     if [ -z "$QUIET_CONSOLE" ]; then
         websocat --no-line ${WS_ADDRESS}/api/jobs/${JOB_ID}/logs/tail | tee "${STREAMCONSUMER_LOGS}job.txt"

--- a/guidebooks/ml/ray/start/local.md
+++ b/guidebooks/ml/ray/start/local.md
@@ -3,7 +3,7 @@
 This will install Ray on your laptop.
 
 ```shell
-export RAY_ADDRESS=http://127.0.0.1:8265
+export KUI_RAY_ADDRESS=http://127.0.0.1:8265
 ```
 
 ```shell


### PR DESCRIPTION
Rename `ray_address` to `kui_ray_address` to follow the `kui_` prefix.

when running codeflare cli in container mode this convention helps to pass the `kui_ray_address` as an environment variable from the pod to guidebook. 