### PR TITLE
feat: leverage new GUIDEBOOK_PROFILE_DATA env var

### DIFF
--- a/guidebooks/ml/ray/run/logs/init.md
+++ b/guidebooks/ml/ray/run/logs/init.md
@@ -3,7 +3,7 @@
 Local staging directory for the logs. Note that on macOS, the `mktemp`
 command behaves a bit differently w.r.t. the template argument.
 ```shell
-export LOGDIR_STAGE=${LOGDIR_STAGE-$(mktemp -d -t logdir-stage$([ $(uname) != "Darwin" ] && echo .XXXXXXX))}
+export LOGDIR_STAGE=${LOGDIR_STAGE-$GUIDEBOOK_PROFILE_DATA_PATH}
 ```
 
 Store the job id in the stage.


### PR DESCRIPTION
instead of using a `mktemp -d` variable for the LOGDIR_STAGE of ml/ray/run/logs