### PR TITLE
fix: using ray[default] to activate ray

### DIFF
--- a/guidebooks/ml/ray/install/cli.md
+++ b/guidebooks/ml/ray/install/cli.md
@@ -4,7 +4,7 @@
 ---
 validate: which ray
 ---
-pip install -U ray ray['default']
+pip install -U "ray[default]"
 ```
 
 ```shell

--- a/guidebooks/ml/ray/start/local.md
+++ b/guidebooks/ml/ray/start/local.md
@@ -17,7 +17,7 @@ export PIP_LOCAL=true
     ---
     validate: pip-show ray
     ---
-    pip install -U ray
+    pip install -U "ray[default]"
     ```
 
 === "Apple Silicon"


### PR DESCRIPTION
only install ray[default], that should take care of installing ray as well as other features that are required by us https://docs.ray.io/en/latest/ray-overview/installation.html#official-releases