### PR TITLE
feat:bring your own training

### DIFF
--- a/guidebooks/ml/codeflare/training/byot/base-ray-image.md
+++ b/guidebooks/ml/codeflare/training/byot/base-ray-image.md
@@ -1,0 +1,6 @@
+# Provide custom base image to be used
+<!-- this will override the default ray image choice in ml/ray/run -->
+=== "Provide custom base image, if any [default: rayproject/ray:1.13.0-py37]"    
+    ```shell    
+    export RAY_IMAGE=${choice}
+    ```

--- a/guidebooks/ml/codeflare/training/byot/index.md
+++ b/guidebooks/ml/codeflare/training/byot/index.md
@@ -1,0 +1,27 @@
+---
+imports:
+    - util/jobid
+    - ./working-directory.md
+    - ./base-ray-image.md
+    - ml/ray/start
+---
+
+# Bring Your Own Training
+
+This path provides a way for you to run your own custom training on a remote ray cluster.
+
+## Run it
+
+Submit the job.
+
+```shell
+export JOB_NAME=BYOT
+```
+
+```shell
+---
+exec: ray job submit  --job-id ${JOB_ID} --no-wait --runtime-env  ${CUSTOM_WORKING_DIR}/runtime-env.yaml --working-dir ${CUSTOM_WORKING_DIR} --address ${RAY_ADDRESS}  -- python main.py 
+---
+```
+
+--8<-- "ml/ray/run/logs"

--- a/guidebooks/ml/codeflare/training/byot/working-directory.md
+++ b/guidebooks/ml/codeflare/training/byot/working-directory.md
@@ -1,0 +1,6 @@
+# Provide location of your working directory
+
+=== "Location of your working directory [default: ./]"
+    ```shell
+    export CUSTOM_WORKING_DIR=${choice}
+    ```

--- a/guidebooks/ml/codeflare/training/index.md
+++ b/guidebooks/ml/codeflare/training/index.md
@@ -9,3 +9,6 @@ by the training process.
 
 === "BERT"
     --8<-- "./bert"
+
+=== "BYOT"
+    --8<-- "./byot"


### PR DESCRIPTION
additional flow added to training to support the ability to bring your own training repo and use that. the training repo is assumed to be derived from template https://github.com/guidebooks/codeflare-template-repo

https://github.com/guidebooks/store/compare/main...atinsood:store:custom_application_merged_v2?expand=1#diff-96e85c3f0a2a6b9054ac677dc591552fd1004314264fbd2bb170e14f46215e35R23 is the entry point