### PR TITLE
fix: starting guidebooks/ml/ray/start/kubernetes/port-forward/mlflow may fail if ray cluster is not up

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/port-forward.md
+++ b/guidebooks/ml/ray/start/kubernetes/port-forward.md
@@ -5,7 +5,6 @@ the Kubernetes services, we set up a number of Kubernetes
 [port-forwards](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/).
 
 --8<-- "./port-forward/ray"
---8<-- "./port-forward/mlflow"
 
 ## Wait, if requested
 

--- a/guidebooks/ml/ray/start/kubernetes/port-forward/mlflow.md
+++ b/guidebooks/ml/ray/start/kubernetes/port-forward/mlflow.md
@@ -1,8 +1,10 @@
 ---
 imports:
     - util/shuf
+    - kubernetes/kubectl
     - kubernetes/context
     - kubernetes/choose/ns
+    - ml/ray/start
 ---
 
 # Port-forward to the MLFlow server


### PR DESCRIPTION
currently, we have combined the ray helm chart and the mlflow pod into a single helm chart. we need to fix that. for now, this PR at least allows this case (starting up the mlflow port forward when the ray cluster is not up) to at least function.