### PR TITLE
Improving ml/ray/run experience on MacOS & Apple Silicon M1

### DIFF
--- a/guidebooks/util/shuf.md
+++ b/guidebooks/util/shuf.md
@@ -7,11 +7,12 @@ validate: which shuf
 The shuf command generates random permutations from input lines to standard output.
 
 === "MacOS"
+    <!-- On MacOS shuf is part of coreutils, but is still invoked with 'shuf' since MacOS Catalina 10.15+ -->
     ```shell
     ---
     validate: which shuf
     ---
-    brew install shuf
+    brew install coreutils
     ```
     
 === "Linux"


### PR DESCRIPTION
Done: A very minor fix
- [x] fix shuf brew install verification, improving other workflows like ml/ray/run

Todo before merge:
To enable the 'laptop to cloud' workflow in Ray, Apple Silicon users will need to use Conda locally due to the `grpcio` dependency. See the [Ray docs Apple Silicon explanation](https://docs.ray.io/en/latest/ray-overview/installation.html#m1-mac-apple-silicon-support).
- [ ] I propose automating this installation by activating a conda env, then `pip uninstall grpcio; conda install grpcio`. The user would simply need conda installed, then codeflare/store will facilitate the creation or allow the user to specify a target conda env for codeflare.

Without this addition, the current behavior crashes on _step 5: Run a Ray Job_ of `ml/ray/run`.
```
$ codeflare ml/ray/run
# setup cluster....
✔  Choice 5: Run a Ray Job  · Example: Using Ray Tasks to Parallelize a Function
▶ Ray Core: Parallelizing Functions with Ray Tasks
# Error....
ImportError:
Failed to import grpc on Apple Silicon. On Apple Silicon machines, try `pip uninstall grpcio; conda install grpcio`. Check out https://docs.ray.io/en/master/ray-overview/installation.html#m1-mac-apple-silicon-support for more details.
```

- [ ] Validating `which ray` (in `ml/ray/install/cli.md`) is insufficient to verify that `ray [default]` is installed. This leads to ray prompting the user to `pip install 'ray[default]'`

This PR is a continuation of #230 after I unsuccessfully tried to rebase commits.