### PR TITLE
fix: ml/codeflare/training/bert no longer needs to launch a local tensorboard

### DIFF
--- a/guidebooks/ml/codeflare/training/bert/index.md
+++ b/guidebooks/ml/codeflare/training/bert/index.md
@@ -37,5 +37,4 @@ exec: ray-submit --job-id ${JOB_ID} --no-wait -- -v --datapath /tmp/ --modelpath
 --8<-- "./ray-bert-vanilla.py"
 ```
 
---8<-- "ml/tensorflow/tensorboard/run"
 --8<-- "ml/ray/run/logs"


### PR DESCRIPTION
we now support launching the tensorboard separately