### PR TITLE
fix: ml/ray/run demo guidebooks do not properly initialize jobid

### DIFF
--- a/guidebooks/ml/ray/run/core/actors.md
+++ b/guidebooks/ml/ray/run/core/actors.md
@@ -1,9 +1,3 @@
----
-imports:
-    - ../../start/index.md
-    - ../../../../util/jobid.md
----
-
 # Ray Core: Parallelizing Classes with Ray Actors
 
 Ray provides actors to allow you to parallelize an instance of a class in Python or Java. When you instantiate a class that is a Ray actor, Ray will start a remote instance of that class in the cluster. This actor can then execute remote method calls and maintain its own internal state.

--- a/guidebooks/ml/ray/run/core/tasks.md
+++ b/guidebooks/ml/ray/run/core/tasks.md
@@ -1,7 +1,8 @@
 ---
 imports:
-    - ml/ray/start
     - util/jobid
+    - ml/ray/run/logs/init
+    - ml/ray/start
 ---
 
 # Ray Core: Parallelizing Functions with Ray Tasks
@@ -18,7 +19,7 @@ future, a so-called Ray object reference, that you can then fetch with
 exec: ray-submit --job-id ${JOB_ID} --no-wait
 ---
 import ray
-ray.init()
+ray.init(address="auto")
 
 @ray.remote
 def f(x):

--- a/guidebooks/ml/ray/run/index.md
+++ b/guidebooks/ml/ray/run/index.md
@@ -1,7 +1,8 @@
 ---
 imports:
-    - ml/ray/start
+    - util/jobid
     - ml/ray/run/logs/init
+    - ml/ray/start
 ---
 
 # Run a Ray Job

--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -31,9 +31,14 @@ Then stream out the logs.
 if [ -n "${LOGDIR_STAGE}" ]; then
   echo
   echo "👉 $(tput setaf 6)Logs will be stored in this local staging directory: $(tput bold)${LOGDIR_STAGE}$(tput sgr0)"
-  echo "👉 $(tput setaf 6)Logs will also be stored in s3: $(tput bold)${LOGDIR_URI}$(tput sgr0)"
+  if [ -n "${LOGDIR_URI}" ]; then
+    echo "👉 $(tput setaf 6)Logs will also be stored in s3: $(tput bold)${LOGDIR_URI}$(tput sgr0)"
+  fi
   if [ -n "${MLFLOW_PORT}" ]; then
     echo "👉 $(tput setaf 6)MLFlow URL: $(tput bold)http://localhost:${MLFLOW_PORT}$(tput sgr0)"
+  fi
+  if [ -n "${TENSORBOARD_PORT}" ]; then
+    echo "👉 $(tput setaf 6)Tensorboard URL: $(tput bold)http://localhost:${TENSORBOARD_PORT}$(tput sgr0)"
   fi
 fi
 ```

--- a/guidebooks/ml/ray/run/serve/examples/gradient-boosting.md
+++ b/guidebooks/ml/ray/run/serve/examples/gradient-boosting.md
@@ -1,8 +1,6 @@
 ---
 imports:
-    - ../../../start/index.md
     - ../../../install/serve.md
-    - ../../../../../util/jobid.md
 ---
 
 # Serve: Scalable Model Serving

--- a/guidebooks/ml/ray/run/train/examples/pytorch/index.md
+++ b/guidebooks/ml/ray/run/train/examples/pytorch/index.md
@@ -1,7 +1,5 @@
 ---
 imports:
-    - ../../../../start/index.md
-    - ../../../../../../util/jobid.md
     - ../../../../../../python/pip/torch.md
 ---
 

--- a/guidebooks/ml/ray/run/tune/examples/grid-search.md
+++ b/guidebooks/ml/ray/run/tune/examples/grid-search.md
@@ -1,8 +1,6 @@
 ---
 imports:
-    - ../../../start/index.md
     - ../../../install/tune.md
-    - ../../../../../util/jobid.md
 ---
 
 # Tune: Hypermarameter Tuning at Scale


### PR DESCRIPTION
we are importing ml/ray/start before util/jobid