### PR TITLE
chore: refactor bring your own training to top-level of ml/codeflare

### DIFF
--- a/guidebooks/ml/codeflare/run.md
+++ b/guidebooks/ml/codeflare/run.md
@@ -4,8 +4,11 @@ I would like to configure and fire off a run.
 
 ## What kind of application do you want to run?
 
-=== "Training"
+=== "Training Demos"
     --8<-- "./training"
 
-=== "Fine Tuning"
+=== "Fine Tuning Demos"
     --8<-- "./tuning"
+
+=== "Bring Your Own Code"
+    --8<-- "./training/byot/index.md"

--- a/guidebooks/ml/codeflare/training/byot/base-ray-image.md
+++ b/guidebooks/ml/codeflare/training/byot/base-ray-image.md
@@ -1,6 +1,6 @@
 # Provide custom base image to be used
 <!-- this will override the default ray image choice in ml/ray/run -->
 === "Provide custom base image, if any [default: rayproject/ray:1.13.0-py37]"    
-    ```shell    
+    ```shell
     export RAY_IMAGE=${choice}
     ```

--- a/guidebooks/ml/codeflare/training/byot/index.md
+++ b/guidebooks/ml/codeflare/training/byot/index.md
@@ -7,21 +7,21 @@ imports:
     - ml/ray/start
 ---
 
-# Bring Your Own Training
+# Bring Your Own Code
 
-This path provides a way for you to run your own custom training on a remote ray cluster.
+This path provides a way for you to run your own custom code on a remote ray cluster.
 
 ## Run it
 
 Submit the job.
 
 ```shell
-export JOB_NAME=BYOT
+export JOB_NAME=BYOC
 ```
 
 ```shell
 ---
-exec: ray job submit  --job-id ${JOB_ID} --no-wait --runtime-env  ${CUSTOM_WORKING_DIR}/runtime-env.yaml --working-dir ${CUSTOM_WORKING_DIR} --address ${RAY_ADDRESS}  -- python main.py 
+exec: ray-submit --job-id ${JOB_ID} --no-wait --working-dir=${CUSTOM_WORKING_DIR} --base-image=${RAY_IMAGE} --entrypoint=main.py
 ---
 ```
 

--- a/guidebooks/ml/codeflare/training/index.md
+++ b/guidebooks/ml/codeflare/training/index.md
@@ -10,7 +10,4 @@ by the training process.
 === "BERT"
     --8<-- "./bert"
 
-=== "BYOT"
-    --8<-- "./byot"
-
 --8<-- "./demos"


### PR DESCRIPTION
This PR also updates the byot index.md to leverage new support from the `ray-submit` intrinsic, for passing working dir.
This PR also renames "Fine Tuning" to "Fine Tuning Demos", same for "Training" to "Training Demos"