### PR TITLE
feat: improve support for arbitrary s3 endpoints and for multiple aws profiles

### DIFF
--- a/guidebooks/aws/_auth.md
+++ b/guidebooks/aws/_auth.md
@@ -8,11 +8,16 @@ validate: |
 To learn more, and to get your credentials from the AWS console, [look
 here](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html).
 
+=== "AWS Endpoint [default: https://s3.amazonaws.com]"
+    ```shell
+    export S3_ENDPOINT=${choice}
+    ```
+
 === "AWS Access Key Id [default: none]"
     ```shell
     export S3_ACCESS_KEY_ID=${choice}
     ```
-    
+
 === "AWS Secret Access Key [default: none]"
     ```shell
     export S3_SECRET_ACCESS_KEY=${choice}

--- a/guidebooks/aws/auth.md
+++ b/guidebooks/aws/auth.md
@@ -1,3 +1,8 @@
+---
+imports:
+    - aws/choose/profile
+---
+
 # AWS Credentials
 
 You may also manually store your AWS credentials in ~/.aws/credentials. The file will look something like
@@ -9,11 +14,15 @@ aws_secret_access_key = yyy
 ```
 
 ```shell
-export S3_ENDPOINT=https://s3.amazonaws.com
+export S3_ENDPOINT_FROM_CONFIG=$(cat ~/.aws/config | awk -v AWS_PROFILE=${AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "endpoint_url" {sub(/endpoint_url *= */,""); print $0}')
 ```
 
 ```shell
-export S3_ACCESS_KEY_ID=$(grep aws_access_key_id ~/.aws/credentials | awk -F ' = ' '{ print $2 }')
+export S3_ENDPOINT=${S3_ENDPOINT_FROM_CONFIG-https://s3.amazonaws.com}
+```
+
+```shell
+export S3_ACCESS_KEY_ID=$(cat ~/.aws/credentials | awk -v AWS_PROFILE=${AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "aws_access_key_id" {sub(/aws_access_key_id *= */,""); print $0}')
 ```
 
 ```shell
@@ -21,7 +30,7 @@ export AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
 ```
 
 ```shell
-export S3_SECRET_ACCESS_KEY=$(grep aws_secret_access_key ~/.aws/credentials | awk -F ' = ' '{ print $2 }')
+export S3_SECRET_ACCESS_KEY=$(cat ~/.aws/credentials | awk -v AWS_PROFILE=${AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "aws_secret_access_key" {sub(/aws_secret_access_key *= */,""); print $0}')
 ```
 
 ```shell

--- a/guidebooks/aws/choose/profile.md
+++ b/guidebooks/aws/choose/profile.md
@@ -1,0 +1,11 @@
+# Choose an AWS Profile
+
+```shell
+if [ ! -d ~/.aws ]; then mkdir ~/.aws; fi
+if [ ! -f ~/.aws/config ]; then echo "[default]" > ~/.aws/config; fi
+```
+
+=== "expand(cat ~/.aws/config | grep -E '^\\[' | tr -d '[]')"
+    ```shell
+    export AWS_PROFILE="${choice}"
+    ```


### PR DESCRIPTION
- we had been assuming that the ~/.aws/credentials file had only one credential pair
- and had been hard-coding an s3 endpoint

on the latter, there isn't a supported solution for this yet (https://github.com/aws/aws-cli/issues/1270). lacking a supported solution, this PR for now assumes that the ~/.aws/config section may have an `endpoint_url=` conf entry.