### PR TITLE
fix: avoid setting the "official" AWS_PROFILE env var

### DIFF
--- a/guidebooks/aws/auth.md
+++ b/guidebooks/aws/auth.md
@@ -14,7 +14,7 @@ aws_secret_access_key = yyy
 ```
 
 ```shell
-export S3_ENDPOINT_FROM_CONFIG=$(cat ~/.aws/config | awk -v AWS_PROFILE=${AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "endpoint_url" {sub(/endpoint_url *= */,""); print $0}')
+export S3_ENDPOINT_FROM_CONFIG=$(cat ~/.aws/config | awk -v AWS_PROFILE=${_AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "endpoint_url" {sub(/endpoint_url *= */,""); print $0}')
 ```
 
 ```shell
@@ -26,7 +26,7 @@ export S3_ENDPOINT_URL=${S3_ENDPOINT}
 ```
 
 ```shell
-export S3_ACCESS_KEY_ID=$(cat ~/.aws/credentials | awk -v AWS_PROFILE=${AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "aws_access_key_id" {sub(/aws_access_key_id *= */,""); print $0}')
+export S3_ACCESS_KEY_ID=$(cat ~/.aws/credentials | awk -v AWS_PROFILE=${_AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "aws_access_key_id" {sub(/aws_access_key_id *= */,""); print $0}')
 ```
 
 ```shell
@@ -34,7 +34,7 @@ export AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
 ```
 
 ```shell
-export S3_SECRET_ACCESS_KEY=$(cat ~/.aws/credentials | awk -v AWS_PROFILE=${AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "aws_secret_access_key" {sub(/aws_secret_access_key *= */,""); print $0}')
+export S3_SECRET_ACCESS_KEY=$(cat ~/.aws/credentials | awk -v AWS_PROFILE=${_AWS_PROFILE-default} '$1 == "[" AWS_PROFILE "]" {on=1} $1 ~ "]" && $1 != "[" AWS_PROFILE "]" {on=0} on==1 && $0 ~ "aws_secret_access_key" {sub(/aws_secret_access_key *= */,""); print $0}')
 ```
 
 ```shell

--- a/guidebooks/aws/choose/profile.md
+++ b/guidebooks/aws/choose/profile.md
@@ -5,7 +5,11 @@ if [ ! -d ~/.aws ]; then mkdir ~/.aws; fi
 if [ ! -f ~/.aws/config ]; then echo "[default]" > ~/.aws/config; fi
 ```
 
+> Note the leading underscore. We don't want to pass this through to
+> any CLI tools or libraries that application code may use. This is
+> just for our internal consumption; e.g. aws/auth
+
 === "expand(cat ~/.aws/config | grep -E '^\\[' | tr -d '[]')"
     ```shell
-    export AWS_PROFILE="${choice}"
+    export _AWS_PROFILE="${choice}"
     ```


### PR DESCRIPTION
we are currently only using this for internal consumption, whereas many clis and libraries use that env var value