### PR TITLE
fix: ml/ray/start/kubernetes can hang if a ray worker pod has died

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -61,7 +61,7 @@ done
 
 ```shell
 while true; do
-    kubectl --context ${KUBE_CONTEXT} wait pod -n ${KUBE_NS} -l ${KUBE_POD_LABEL_SELECTOR} --for=condition=Ready --timeout=600s | grep -v 'no matching resources' > /dev/null && break || echo "Waiting for Ray Worker nodes"
+    kubectl --context ${KUBE_CONTEXT} get pod -n ${KUBE_NS} -l ${KUBE_POD_LABEL_SELECTOR} | grep Running > /dev/null && break || echo "Waiting for Ray Worker nodes"
     sleep 1
 done
 ```


### PR DESCRIPTION
We were using `kubectl wait --for=condition=Ready` with a label-selector. The `kubectl` behavior with this combination is to wait for *all* pods to have that condition. Thus, if just one pod has died, at any point in the past, and is thus in an Error state, or perhaps Completed state... the guidebook hangs.

This PR switches to use polling. I don't see how we can use `kubectl wait` with some sort of exclusion.  ref: https://github.com/kubernetes/kubernetes/issues/87747

Also, the `--for=jsonpath` does not support negation (i had thought to use a !=Pending... which is really what we want).

Also with this PR, the guidebook will succeed when at least one pod is Ready. Previously, we would wait for *all* pods to be ready. Probably a good thing, too?