### PR TITLE
fix: tensorboard in kubernetes should pin a version

### DIFF
--- a/guidebooks/ml/tensorboard/start/kubernetes/chart/templates/tensorboard.yaml
+++ b/guidebooks/ml/tensorboard/start/kubernetes/chart/templates/tensorboard.yaml
@@ -19,7 +19,7 @@ spec:
       - name: tensorboard-server
 #        imagePullPolicy: IfNotPresent
 #        image: ghcr.io/project-codeflare/tensorboard
-        image: starpit/tensorboard
+        image: starpit/tensorboard:0.0.1
         command: ["tensorboard"]
         args: ["--host=0.0.0.0", "--logdir={{ .Values.s3.bucket }}", "--port={{ .Values.port }}"]
         env:


### PR DESCRIPTION
This PR pins to starpit/tensorboard:0.0.1