### PR TITLE
fix: avoid use of ray CLI for ray job status poll in ml/ray/run/logs

### DIFF
--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -22,7 +22,7 @@ We will stream out a suite of data, including resource utilization metrics and j
 Wait for the job to be active.
 
 ```shell
-while true; do if [ "$(ray job status ${JOB_ID} >& /dev/null && echo 1 || echo 0)" = "1" ]; then break; sleep 1; fi; done
+while true; do if [ "$(curl -s -I $RAY_ADDRESS/api/jobs/$JOB_ID | head -n 1 | cut -d$' ' -f2)" = "200" ]; then break; sleep 1; fi; done
 ```
 
 Then stream out the logs.


### PR DESCRIPTION
This PR switches over to a rather simpler curl command, to avoid a requirement of the `ray` CLI just to poll for the status of a job.