### PR TITLE
fix: change `--context ${KUBE_CONTEXT}` to `${KUBE_CONTEXT_ARG}`

### DIFF
--- a/guidebooks/kubernetes/choose/ns.md
+++ b/guidebooks/kubernetes/choose/ns.md
@@ -11,6 +11,10 @@ imports:
     export KUBE_NS=${choice}
     ```
 
+    ```shell
+    export KUBE_NS_ARG="-n ${choice}"
+    ```
+
 === "Create a namespace"
     ```shell
     kubectl create ns madns

--- a/guidebooks/kubernetes/context.md
+++ b/guidebooks/kubernetes/context.md
@@ -9,3 +9,11 @@ imports:
     ```shell
     export KUBE_CONTEXT="${choice}"
     ```
+
+    ```shell
+    export KUBE_CONTEXT_ARG="--context ${choice}"
+    ```
+
+    ```shell
+    export KUBE_CONTEXT_ARG_HELM="--kube-context ${choice}"
+    ```

--- a/guidebooks/ml/mlflow/start/kubernetes/install.md
+++ b/guidebooks/ml/mlflow/start/kubernetes/install.md
@@ -18,7 +18,7 @@ export S3_BUCKETMLFLOW=${S3_BUCKETRAYLOGS}/mlflow
 ```shell
 ---
 validate: |
-  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} get deploy mlflow; else exit 1; fi
+  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} get deploy mlflow; else exit 1; fi
 ---
 --8<-- "./install.sh"
 ```

--- a/guidebooks/ml/mlflow/start/kubernetes/port-forward.md
+++ b/guidebooks/ml/mlflow/start/kubernetes/port-forward.md
@@ -14,7 +14,7 @@ export MLFLOW_PORT=${MLFLOW_PORT-$(shuf -i 8266-9999 -n1)}
 ```
 
 ```shell.async
-kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} port-forward service/mlflow-service ${MLFLOW_PORT}:9080 > /tmp/port-forward-mlflow
+kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/mlflow-service ${MLFLOW_PORT}:9080 > /tmp/port-forward-mlflow
 ```
 
 ```shell

--- a/guidebooks/ml/mlflow/stop/kubernetes/index.md
+++ b/guidebooks/ml/mlflow/stop/kubernetes/index.md
@@ -10,5 +10,5 @@ imports:
 Stop The MLFlow Server in Kubernetes.
 
 ```shell
-helm --kube-context ${KUBE_CONTEXT} -n ${KUBE_NS} uninstall mlflow
+helm ${KUBE_CONTEXT_ARG_HELM} ${KUBE_NS_ARG} uninstall mlflow
 ```

--- a/guidebooks/ml/ray/cluster/kubernetes/is-installed.md
+++ b/guidebooks/ml/ray/cluster/kubernetes/is-installed.md
@@ -13,7 +13,7 @@ your Kubernetes cluster. It does not check whether there is a quorum
 of head and worker nodes ready. For that, use `ml/ray/cluster/kubernetes/is-ready`
 
 ```shell
-helm status --kube-context ${KUBE_CONTEXT} -n ${KUBE_NS} ${RAY_KUBE_CLUSTER_NAME-mycluster} -o json | jq .info
+helm status ${KUBE_CONTEXT_ARG_HELM} ${KUBE_NS_ARG} ${RAY_KUBE_CLUSTER_NAME-mycluster} -o json | jq .info
 ```
 
 This guidebook will `exit 1` if your Ray cluster has not been

--- a/guidebooks/ml/ray/cluster/kubernetes/is-ready.md
+++ b/guidebooks/ml/ray/cluster/kubernetes/is-ready.md
@@ -9,7 +9,7 @@ imports:
 # Ray-in-Kubernetes Cluster Readiness
 
 ```shell
-export RAY_MAX_WORKERS=$(kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} get raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} -o json | jq '.spec.podTypes | .[] | select(.name=="rayWorkerType") | .maxWorkers')
+export RAY_MAX_WORKERS=$(kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} get raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} -o json | jq '.spec.podTypes | .[] | select(.name=="rayWorkerType") | .maxWorkers')
 ```
 
 Emit the initial state
@@ -20,7 +20,7 @@ echo "workers 0/${RAY_MAX_WORKERS-1}"
 
 ```shell
 kubectl get pod \
-  --context ${KUBE_CONTEXT} -n ${KUBE_NS} \
+  ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} \
   -l ray-cluster-name=${RAY_KUBE_CLUSTER_NAME-mycluster} \
   --watch --no-headers \
   -o custom-columns=NAME:.metadata.name,TYPE:.metadata.labels.ray-node-type,STATUS:.status.phase \

--- a/guidebooks/ml/ray/hacks/openshift/uid-range.md
+++ b/guidebooks/ml/ray/hacks/openshift/uid-range.md
@@ -20,9 +20,9 @@ by default ([reference](https://access.redhat.com/solutions/2801791)).
     ```shell
     ---
     validate: |
-      [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ] && [ $(kubectl get ns ${KUBE_NS} --context ${KUBE_CONTEXT} -o json | jq -r '.metadata.annotations."openshift.io/sa.scc.uid-range"') = "1000/10000" ]
+      [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ] && [ $(kubectl get ns ${KUBE_NS} ${KUBE_CONTEXT_ARG} -o json | jq -r '.metadata.annotations."openshift.io/sa.scc.uid-range"') = "1000/10000" ]
     ---
-    kubectl annotate namespace ${KUBE_NS} --context ${KUBE_CONTEXT} --overwrite openshift.io/sa.scc.uid-range=1000/10000
+    kubectl annotate namespace ${KUBE_NS} ${KUBE_CONTEXT_ARG} --overwrite openshift.io/sa.scc.uid-range=1000/10000
     ```
 
     Not changing the UID can cause permissions problems when the Ray

--- a/guidebooks/ml/ray/run/job-definition.md
+++ b/guidebooks/ml/ray/run/job-definition.md
@@ -16,7 +16,7 @@ INPUT=$(cat "${LOGDIR_STAGE}/ray-job-definition.json" | jq -r .entrypoint | awk 
 PKGDIR=$(cat "${LOGDIR_STAGE}/ray-job-definition.json" | jq -r .runtime_env.working_dir | sed 's#gcs://##' | sed 's/\.zip//')
 
 if [ -n "$KUBE_CONTEXT" ] && [ -n "$KUBE_NS" ]; then
-    kubectl exec --context ${KUBE_CONTEXT} -n ${KUBE_NS} ${RAY_HEAD_POD} -- cat /tmp/ray/session_latest/runtime_resources/working_dir_files/${PKGDIR}/${INPUT} >> "${LOGDIR_STAGE}/source.py"
+    kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${RAY_HEAD_POD} -- cat /tmp/ray/session_latest/runtime_resources/working_dir_files/${PKGDIR}/${INPUT} >> "${LOGDIR_STAGE}/source.py"
 fi
 
 while true; do

--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -17,7 +17,7 @@ This will install Ray on a Kubernetes context of your choosing.
 ## Stream out Events from the Ray Head Node
 
 ```shell.async
-kubectl get events --context ${KUBE_CONTEXT} -n ${KUBE_NS} --watch-only | tee "${STREAMCONSUMER_EVENTS}kubernetes.txt"
+kubectl get events ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} --watch-only | tee "${STREAMCONSUMER_EVENTS}kubernetes.txt"
 ```
 
 ### Use Helm to create the Ray Cluster
@@ -50,7 +50,7 @@ export RAY_KUBE_CLUSTER_NAME=mycluster
 
 ```shell
 while true; do
-    kubectl --context ${KUBE_CONTEXT} get pod -n ${KUBE_NS} -l ${KUBE_POD_RAY_HEAD_LABEL_SELECTOR} | grep Running > /dev/null && break || echo "Waiting for Ray Head node"
+    kubectl ${KUBE_CONTEXT_ARG} get pod ${KUBE_NS_ARG} -l ${KUBE_POD_RAY_HEAD_LABEL_SELECTOR} | grep Running > /dev/null && break || echo "Waiting for Ray Head node"
     sleep 1
 done
 ```
@@ -61,7 +61,7 @@ done
 
 ```shell
 while true; do
-    kubectl --context ${KUBE_CONTEXT} get pod -n ${KUBE_NS} -l ${KUBE_POD_LABEL_SELECTOR} | grep Running > /dev/null && break || echo "Waiting for Ray Worker nodes"
+    kubectl ${KUBE_CONTEXT_ARG} get pod ${KUBE_NS_ARG} -l ${KUBE_POD_LABEL_SELECTOR} | grep Running > /dev/null && break || echo "Waiting for Ray Worker nodes"
     sleep 1
 done
 ```

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.md
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.md
@@ -3,7 +3,7 @@
 ```shell
 ---
 validate: |
-  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then X=$(kubectl --context ${KUBE_CONTEXT} get raycluster ${RAY_KUBE_CLUSTER_NAME} -n ${KUBE_NS} -o json 2>&1); echo "$X" | grep -v 'No resources' && echo "$X" | grep -v 'not found' && [ $(echo "$X" | jq '.spec.podTypes | .[] | select(.name=="rayWorkerType") | .podConfig.spec.containers[0].resources.requests.cpu') = ${NUM_CPUS-1} ]; else exit 1; fi
+  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then X=$(kubectl ${KUBE_CONTEXT_ARG} get raycluster ${RAY_KUBE_CLUSTER_NAME} ${KUBE_NS_ARG} -o json 2>&1); echo "$X" | grep -v 'No resources' && echo "$X" | grep -v 'not found' && [ $(echo "$X" | jq '.spec.podTypes | .[] | select(.name=="rayWorkerType") | .podConfig.spec.containers[0].resources.requests.cpu') = ${NUM_CPUS-1} ]; else exit 1; fi
 ---
 --8<-- "./install-via-helm.sh"
 ```

--- a/guidebooks/ml/ray/start/kubernetes/port-forward/ray.md
+++ b/guidebooks/ml/ray/start/kubernetes/port-forward/ray.md
@@ -10,7 +10,7 @@ imports:
 To facilitate communication to the Ray API.
 
 ```shell.async
-kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} port-forward service/${RAY_KUBE_CLUSTER_NAME-mycluster}-ray-head ${RAY_KUBE_PORT-8266}:8265 > /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster}
+kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/${RAY_KUBE_CLUSTER_NAME-mycluster}-ray-head ${RAY_KUBE_PORT-8266}:8265 > /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster}
 ```
 
 ### Wait for the ray port forwarder to become active

--- a/guidebooks/ml/ray/stop/kubernetes.md
+++ b/guidebooks/ml/ray/stop/kubernetes.md
@@ -14,7 +14,7 @@ First, we need to delete the cluster resource, to make sure finalizers
 are processed properly.
 
 ```shell
-kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} delete raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} --wait=false || exit 0
+kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} delete raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} --wait=false || exit 0
 ```
 
 ## Clear out potentially stuck finalizers
@@ -22,7 +22,7 @@ kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} delete raycluster ${RAY_KUBE_CLU
 ```shell
 if [ -z "$NOFORCE_STOP" ]; then
     echo "Patching finalizer"
-    kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} patch raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} -p '{"metadata":{"finalizers":null}}' --type=merge 2> /dev/null || exit 0
+    kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} patch raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} -p '{"metadata":{"finalizers":null}}' --type=merge 2> /dev/null || exit 0
 fi
 ```
 
@@ -31,5 +31,5 @@ fi
 Now we can delete the cluster.
 
 ```shell
-helm --kube-context ${KUBE_CONTEXT} -n ${KUBE_NS} delete ${RAY_KUBE_CLUSTER_NAME-mycluster} || exit 0
+helm ${KUBE_CONTEXT_ARG_HELM} ${KUBE_NS_ARG} delete ${RAY_KUBE_CLUSTER_NAME-mycluster} || exit 0
 ```

--- a/guidebooks/ml/tensorboard/start/kubernetes/install.md
+++ b/guidebooks/ml/tensorboard/start/kubernetes/install.md
@@ -18,7 +18,7 @@ export S3_BUCKETTENSORBOARD=${S3_BUCKETRAYLOGS}/tensorboard
 ```shell
 ---
 validate: |
-  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} get deploy tensorboard; else exit 1; fi
+  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} get deploy tensorboard; else exit 1; fi
 ---
 --8<-- "./install.sh"
 ```

--- a/guidebooks/ml/tensorboard/start/kubernetes/port-forward.md
+++ b/guidebooks/ml/tensorboard/start/kubernetes/port-forward.md
@@ -14,7 +14,7 @@ export TENSORBOARD_PORT=${TENSORBOARD_PORT-$(shuf -i 8266-9999 -n1)}
 ```
 
 ```shell.async
-kubectl --context ${KUBE_CONTEXT} -n ${KUBE_NS} port-forward service/tensorboard-service ${TENSORBOARD_PORT}:9080 > /tmp/port-forward-tensorboard
+kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/tensorboard-service ${TENSORBOARD_PORT}:9080 > /tmp/port-forward-tensorboard
 ```
 
 ```shell

--- a/guidebooks/ml/tensorboard/stop/kubernetes/index.md
+++ b/guidebooks/ml/tensorboard/stop/kubernetes/index.md
@@ -10,5 +10,5 @@ imports:
 Stop The Tensorboard Server in Kubernetes.
 
 ```shell
-helm --kube-context ${KUBE_CONTEXT} -n ${KUBE_NS} uninstall tensorboard
+helm ${KUBE_CONTEXT_ARG_HELM} ${KUBE_NS_ARG} uninstall tensorboard
 ```

--- a/guidebooks/ml/tensorflow/tensorboard/rsync.md
+++ b/guidebooks/ml/tensorflow/tensorboard/rsync.md
@@ -25,5 +25,5 @@
     ```
 
     ```shell.async
-    while true; do kubectl get pod -l ${KUBE_POD_LABEL_SELECTOR} -n ${KUBE_NS} --template '{{range .items}}{{.metadata.name}}{{end}}' | xargs -I POD -n1 rsync --inplace --archive --no-owner --no-group --omit-dir-times --numeric-ids --quiet --rsh="oc rsh -n ${KUBE_NS} --context ${KUBE_CONTEXT}" POD:${TB_LOGDIR} ${TB_LOCAL_LOGDIR_FOR_RSYNC}; sleep 10; done
+    while true; do kubectl get pod -l ${KUBE_POD_LABEL_SELECTOR} ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} --template '{{range .items}}{{.metadata.name}}{{end}}' | xargs -I POD -n1 rsync --inplace --archive --no-owner --no-group --omit-dir-times --numeric-ids --quiet --rsh="oc rsh ${KUBE_NS_ARG} ${KUBE_CONTEXT_ARG}" POD:${TB_LOGDIR} ${TB_LOCAL_LOGDIR_FOR_RSYNC}; sleep 10; done
     ```

--- a/guidebooks/s3/create/kubernetes/secret.md
+++ b/guidebooks/s3/create/kubernetes/secret.md
@@ -7,5 +7,5 @@ imports:
 # Create a Kubernetes Secret to Access your S3 Data
 
 ```shell
-kubectl create secret generic --context ${KUBE_CONTEXT} -n ${KUBE_NS} guidebook-s3-${S3_SERVICE} --from-literal S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" --from-literal S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" --from-literal S3_ENDPOINT="${S3_ENDPOINT}"
+kubectl create secret generic ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} guidebook-s3-${S3_SERVICE} --from-literal S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" --from-literal S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" --from-literal S3_ENDPOINT="${S3_ENDPOINT}"
 ```


### PR DESCRIPTION
And the same for `-n ${KUBE_NS}` to `${KUBE_NS_ARG}`.

This allows us to run in situations where we do not want to set any `--context` or `-n` options. For example, when running inside a kubernetes cluster, `kubectl` is smart enough to pick up this information automatically. I don't see any way to pass some kind of fake context name in-cluster. For namespace... this *is* knowable, even in-cluster, but I figured we should make this change uniformly here.