### PR TITLE
fix: ml/ray/cluster does not need the ray CLI

### DIFF
--- a/guidebooks/ml/ray/cluster/index.md
+++ b/guidebooks/ml/ray/cluster/index.md
@@ -1,8 +1,3 @@
----
-imports:
-    - ml/ray/install/cli
----
-
 # Pick a Ray Target
 
 === "My Cluster is Running Locally"


### PR DESCRIPTION
Maybe this was a leftover from earlier versions which did require it.