### PR TITLE
fix: ml/ray/aggregator/in-cluster/client-side should use guidebook on command line

### DIFF
--- a/guidebooks/ml/ray/aggregator/in-cluster/client-side/aggregator.yaml
+++ b/guidebooks/ml/ray/aggregator/in-cluster/client-side/aggregator.yaml
@@ -46,9 +46,7 @@ spec:
       image: ghcr.io/project-codeflare/codeflare-log-aggregator
       env:
         - name: LOG_AGGREGATOR_POD
-          value: guidebook-log-aggregator
-        - name: GUIDEBOOK
-          value: ml/ray/aggregator/in-cluster/server-side/start
+          value: guidebook-log-aggregator # TODO somehow share this with ./names.md
 #        volumeMounts:
 #          - name: profile-volume
 #            mountPath: /home/codeflare/.local/share/madwizard-nodejs/profiles/default

--- a/guidebooks/ml/ray/aggregator/in-cluster/client-side/start/with-jobid.md
+++ b/guidebooks/ml/ray/aggregator/in-cluster/client-side/start/with-jobid.md
@@ -18,6 +18,6 @@ kubectl wait ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} pod/${LOG_AGGREGATOR_POD_NAME} -
 
 Now we can stream.
 ```shell
-kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${LOG_AGGREGATOR_POD_NAME} -- env JOB_ID=$JOB_ID codeflare
+kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${LOG_AGGREGATOR_POD_NAME} -- \
+    env JOB_ID=$JOB_ID codeflare ml/ray/aggregator/in-cluster/server-side/start
 ```
-


### PR DESCRIPTION
We had been using a GUIDEBOOK set in the aggregator.yaml. It will be clearer to pass this through explicitly in the command line in ml/ray/aggregator/in-cluster/client-side/start/with-jobid.md