### PR TITLE
fix: client-side of in-cluster log aggregator may fail to stream certain content

### DIFF
--- a/guidebooks/ml/ray/run/gpu-utilization.sh
+++ b/guidebooks/ml/ray/run/gpu-utilization.sh
@@ -2,7 +2,7 @@ if [ -z "$KUBE_CONTEXT" ] || [ -z "$KUBE_NS" ]; then exit; fi
 
 if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
     kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${LOG_AGGREGATOR_POD_NAME} -- \
-            tail -f -n +1 "$LOG_AGGREGATOR_LOGDIR"/resources/gpu.txt > "${STREAMCONSUMER_RESOURCES}gpu.txt"
+            wait-for-and-tailf "$LOG_AGGREGATOR_LOGDIR"/resources/gpu.txt > "${STREAMCONSUMER_RESOURCES}gpu.txt"
     exit
 fi
 

--- a/guidebooks/ml/ray/run/node-stats.sh
+++ b/guidebooks/ml/ray/run/node-stats.sh
@@ -2,7 +2,7 @@ if [ -z "$KUBE_CONTEXT" ] || [ -z "$KUBE_NS" ]; then exit; fi
 
 if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
     kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${LOG_AGGREGATOR_POD_NAME} -- \
-            tail -f -n +1 "$LOG_AGGREGATOR_LOGDIR"/resources/node-stats.txt > "${STREAMCONSUMER_RESOURCES}node-stats.txt"
+            wait-for-and-tailf "$LOG_AGGREGATOR_LOGDIR"/resources/node-stats.txt > "${STREAMCONSUMER_RESOURCES}node-stats.txt"
     exit
 fi
 

--- a/guidebooks/ml/ray/run/pod-stats.sh
+++ b/guidebooks/ml/ray/run/pod-stats.sh
@@ -2,7 +2,7 @@ if [ -z "$KUBE_CONTEXT" ] || [ -z "$KUBE_NS" ]; then exit; fi
 
 if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
     kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${LOG_AGGREGATOR_POD_NAME} -- \
-            tail -f -n +1 "$LOG_AGGREGATOR_LOGDIR"/resources/pod-stats.txt > "${STREAMCONSUMER_RESOURCES}pod-stats.txt"
+            wait-for-and-tailf "$LOG_AGGREGATOR_LOGDIR"/resources/pod-stats.txt > "${STREAMCONSUMER_RESOURCES}pod-stats.txt"
     exit
 fi
 

--- a/guidebooks/ml/ray/run/pod-vmstat-memory.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat-memory.sh
@@ -5,7 +5,7 @@ sleep 0.$(shuf -i 10000-11000 -n1)
 
 if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
     kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${LOG_AGGREGATOR_POD_NAME} -- \
-            tail -f -n +1 "$LOG_AGGREGATOR_LOGDIR"/resources/pod-memory.txt > "${STREAMCONSUMER_RESOURCES}pod-memory.txt"
+            wait-for-and-tailf "$LOG_AGGREGATOR_LOGDIR"/resources/pod-memory.txt > "${STREAMCONSUMER_RESOURCES}pod-memory.txt"
     exit
 fi
 

--- a/guidebooks/ml/ray/run/pod-vmstat.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat.sh
@@ -5,7 +5,7 @@ sleep 0.$(shuf -i 5000-7000 -n1)
 
 if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
     kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${LOG_AGGREGATOR_POD_NAME} -- \
-            tail -f -n +1 "$LOG_AGGREGATOR_LOGDIR"/resources/pod-vmstat.txt > "${STREAMCONSUMER_RESOURCES}pod-vmstat.txt"
+            wait-for-and-tailf "$LOG_AGGREGATOR_LOGDIR"/resources/pod-vmstat.txt > "${STREAMCONSUMER_RESOURCES}pod-vmstat.txt"
     exit
 fi
 


### PR DESCRIPTION

If the client-side starts streaming before the server-side has any data, the tail -f's will exit and never recover.

This PR introduces a script `wait-for-and-tailf` which relies on `inotifywait` (part of `inotify-tools` for ubuntu) to wait for a file to exist (using push notifications from inotify), and then start tailing.

TODO: how can we get this utility into the store?