### PR TITLE
fix: ml/ray/aggregator/setup has typos that result in empty JOB_ENV a…

### DIFF
--- a/guidebooks/ml/ray/aggregator/setup.md
+++ b/guidebooks/ml/ray/aggregator/setup.md
@@ -22,11 +22,11 @@ export JOB_ENV=$(
         echo "Please set RAY_ADDRESS"
         exit 1
     else
-        echo $(curl $RAY_ADDRESS/api/jobs/$JOB_ID')
+        echo $(curl -s $RAY_ADDRESS/api/jobs/$JOB_ID)
     fi
 )
 ```
 
 ```shell
-export NUM_GPUS=$(echo "$JOB_ENV" | jq -cr '.runtime_env.env_vars.NUM_GPUS)
+export NUM_GPUS=$(echo "$JOB_ENV" | jq -cr '.runtime_env.env_vars.NUM_GPUS')
 ```


### PR DESCRIPTION
…nd NUM_GPUS