### PR TITLE
feat: update ray runners not to start up aggregator

### DIFF
--- a/guidebooks/ml/codeflare/training/bert/index.md
+++ b/guidebooks/ml/codeflare/training/bert/index.md
@@ -32,9 +32,7 @@ export TB_LOGDIR="${LOGDIR_URI}/tensorboard/"
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait -- -v --datapath /tmp/ --modelpath /tmp/ --logpath /tmp/ --tblogpath "${TB_LOGDIR}" --num_workers ${NUM_GPUs-${NUM_CPUS-1}} ${GPU_OPTION} ${GUIDEBOOK_DASHDASH}
+exec: ray-submit --job-id ${JOB_ID} -- -v --datapath /tmp/ --modelpath /tmp/ --logpath /tmp/ --tblogpath "${TB_LOGDIR}" --num_workers ${NUM_GPUs-${NUM_CPUS-1}} ${GPU_OPTION} ${GUIDEBOOK_DASHDASH}
 ---
 --8<-- "./ray-bert-vanilla.py"
 ```
-
---8<-- "ml/ray/run/logs"

--- a/guidebooks/ml/codeflare/training/byot/index.md
+++ b/guidebooks/ml/codeflare/training/byot/index.md
@@ -22,8 +22,6 @@ export JOB_NAME=BYOC
 
 ```shell
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait --working-dir=${CUSTOM_WORKING_DIR} --base-image=${RAY_IMAGE} --entrypoint=main.py -- ${GUIDEBOOK_DASHDASH}
+exec: ray-submit --job-id ${JOB_ID} --working-dir=${CUSTOM_WORKING_DIR} --base-image=${RAY_IMAGE} --entrypoint=main.py -- ${GUIDEBOOK_DASHDASH}
 ---
 ```
-
---8<-- "ml/ray/run/logs"

--- a/guidebooks/ml/codeflare/training/demos/mlflow/index.md
+++ b/guidebooks/ml/codeflare/training/demos/mlflow/index.md
@@ -30,9 +30,7 @@ export JOB_NAME=MLFlowDemo
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 --8<-- "./main.py"
 ```
-
---8<-- "ml/ray/run/logs"

--- a/guidebooks/ml/codeflare/training/demos/tensorboard/index.md
+++ b/guidebooks/ml/codeflare/training/demos/tensorboard/index.md
@@ -33,9 +33,7 @@ export TB_LOGDIR="s3://${S3_BUCKETRAYLOGS}/tensorboard/${JOB_ID}"
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 --8<-- "./main.py"
 ```
-
---8<-- "ml/ray/run/logs"

--- a/guidebooks/ml/codeflare/tuning/glue/index.md
+++ b/guidebooks/ml/codeflare/tuning/glue/index.md
@@ -40,10 +40,8 @@ export WANDB_DISABLED=true
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait -- -v -b ${S3_BUCKET} -m ${S3_OBJECTMODEL} -g ${S3_OBJECTGLUEDATA} -t WNLI -M -s 40 41 42 43 ${GUIDEBOOK_DASHDASH}
+exec: ray-submit --job-id ${JOB_ID} -- -v -b ${S3_BUCKET} -m ${S3_OBJECTMODEL} -g ${S3_OBJECTGLUEDATA} -t WNLI -M -s 40 41 42 43 ${GUIDEBOOK_DASHDASH}
 ---
 --8<-- "./glue_benchmark.py"
 ```
-
---8<-- "ml/ray/run/logs"
 

--- a/guidebooks/ml/ray/run/core/actors.md
+++ b/guidebooks/ml/ray/run/core/actors.md
@@ -4,7 +4,7 @@ Ray provides actors to allow you to parallelize an instance of a class in Python
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 import ray
 ray.init() # Only call this once.
@@ -25,5 +25,3 @@ counters = [Counter.remote() for i in range(4)]
 futures = [c.read.remote() for c in counters]
 print(ray.get(futures)) # [1, 1, 1, 1]
 ```
-
---8<-- "../logs.md"

--- a/guidebooks/ml/ray/run/core/tasks.md
+++ b/guidebooks/ml/ray/run/core/tasks.md
@@ -9,7 +9,7 @@ future, a so-called Ray object reference, that you can then fetch with
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 import ray
 ray.init(address="auto")
@@ -25,6 +25,4 @@ print(ray.get(futures)) # [0, 1, 4, 9]
 In the above code block we defined some Ray Tasks. While these are
 great for stateless operations, sometimes you must maintain the state
 of your application. You can do that with Ray Actors.
-
---8<-- "ml/ray/run/logs"
 

--- a/guidebooks/ml/ray/run/data/create/from-file.md
+++ b/guidebooks/ml/ray/run/data/create/from-file.md
@@ -22,7 +22,7 @@ operation is finished. Datasets also supports `.filter()` and
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 import ray
 import pandas as pd
@@ -54,5 +54,3 @@ ds.flat_map(lambda x: [x, -x]).take(5)
 # -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1568.10it/s]
 # -> [0, 0, 2, -2, 4]
 ```
-
---8<-- "../../logs.md"

--- a/guidebooks/ml/ray/run/data/create/from-range.md
+++ b/guidebooks/ml/ray/run/data/create/from-range.md
@@ -12,7 +12,7 @@ Arrow](https://arrow.apache.org/docs/python/api/datatypes.html)).
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 import ray
 
@@ -41,5 +41,3 @@ ds.schema()
 # -> col1: int64
 # -> col2: string
 ```
-
---8<-- "../../logs.md"

--- a/guidebooks/ml/ray/run/serve/examples/gradient-boosting.md
+++ b/guidebooks/ml/ray/run/serve/examples/gradient-boosting.md
@@ -9,7 +9,7 @@ imports:
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 # This example runs serves a [scikit-learn](https://scikit-learn.org/) gradient boosting classifier.
 
@@ -51,5 +51,3 @@ response = requests.get(
     "http://localhost:8000/iris", json=sample_request_input)
 print(response.text)
 ```
-
---8<-- "../../logs.md"

--- a/guidebooks/ml/ray/run/train/examples/pytorch/index.md
+++ b/guidebooks/ml/ray/run/train/examples/pytorch/index.md
@@ -9,7 +9,7 @@ This example shows how you can use Ray Train with PyTorch.
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 # First, set up your dataset and model.
 --8<-- "./nn.py"
@@ -26,5 +26,3 @@ exec: ray-submit --job-id ${JOB_ID} --no-wait
 # Then, instantiate a Trainer that uses a "torch" backend with 4 workers, and use it to run the new training function!
 --8<-- "./trainer.py"
 ```
-
---8<-- "../../../logs.md"

--- a/guidebooks/ml/ray/run/tune/examples/grid-search.md
+++ b/guidebooks/ml/ray/run/tune/examples/grid-search.md
@@ -9,7 +9,7 @@ imports:
 
 ```python
 ---
-exec: ray-submit --job-id ${JOB_ID} --no-wait
+exec: ray-submit --job-id ${JOB_ID}
 ---
 # This example runs a small grid search with an iterative training function.
 from ray import tune
@@ -30,6 +30,4 @@ search_space = {
 analysis = tune.run(objective, config=search_space)
 print(analysis.get_best_config(metric="score", mode="min"))
 ```
-
---8<-- "../../logs.md"
 


### PR DESCRIPTION
With this change, the main ray runners do not launch the log aggregator. We may want to revisit this at some point, e.g. so that the aggregator is launched upon job submission, so that all of the resource and event metrics are collected.

However, that will be a separate change, because, as it stands, the ray runners do not launch the aggregator proper, but instead point to a guidebook a bit deeper (`ml/ray/run/logs`; one that the aggregator also uses). 

So... with the switch to a server-side log aggregator, some change here is needed. I have decided to make that change in two passes. First, in this PR, the run launching guidebooks will not call that "internal" guidebook. Later, we can consider having them instead use the aggregator proper.