### PR TITLE
fix: add missing dependences for GLUE

### DIFF
--- a/guidebooks/ml/codeflare/tuning/glue/pip.txt
+++ b/guidebooks/ml/codeflare/tuning/glue/pip.txt
@@ -4,3 +4,8 @@ ray_lightning
 pytorch_lightning
 torchvision
 transformers==3.0.2
+requests
+scikit-learn
+
+--find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.12.1+cu116


### PR DESCRIPTION
- requests
- scikit-learn

This PR also bumps torch to cuda11. The ray base image uses torch 1.12.1 with cuda10. Newer NVidia GPUs require cuda11.

TODO:

- this has to be something we detect, right?
- should we be using an alternate base image? so as not to download torch twice, i.e. once from the ray base image and once in our pip)? (around 2GB each!)