### PR TITLE
feat: allow "keep it simple" ray charts to install ray cli on demand

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -54,12 +54,17 @@ spec:
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "-c", "--" ]
           args:
-            - {{ print "ray start --head --port=6379 --redis-shard-ports=6380,6381 --num-cpus=" .Values.podTypes.rayHeadType.CPU " --num-gpus=" .Values.podTypes.rayHeadType.GPU " --object-manager-port=22345 --node-manager-port=22346 --dashboard-host=0.0.0.0 --block" }}
+            - {{ print "if ! $(which ray); then pip install ray[default]==" .Values.failsafes.ray.version "; fi; ray start --head --port=6379 --redis-shard-ports=6380,6381 --num-cpus=" .Values.podTypes.rayHeadType.CPU " --num-gpus=" .Values.podTypes.rayHeadType.GPU " --object-manager-port=22345 --node-manager-port=22346 --dashboard-host=0.0.0.0 --block" }}
           ports:
             - containerPort: 6379 # Redis port
             - containerPort: 10001 # Used by Ray Client
             - containerPort: 8265 # Used by Ray Dashboard
             - containerPort: 8000 # Used by Ray Serve
+
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8265
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
@@ -41,7 +41,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash", "-c", "--"]
         args:
-          - {{ print "ray start --num-cpus=" .Values.podTypes.rayWorkerType.CPU " --num-gpus=" .Values.podTypes.rayWorkerType.GPU " --address=" (include "ray.headService" .) ":6379 --object-manager-port=22345 --node-manager-port=22346 --block" }}
+          - {{ print "if ! $(which ray); then pip install ray[default]==" .Values.failsafes.ray.version "; fi;  ray start --num-cpus=" .Values.podTypes.rayWorkerType.CPU " --num-gpus=" .Values.podTypes.rayWorkerType.GPU " --address=" (include "ray.headService" .) ":6379 --object-manager-port=22345 --node-manager-port=22346 --block" }}
         # This volume allocates shared memory for Ray to use for its plasma
         # object store. If you do not provide this, Ray will fall back to
         # /tmp which cause slowdowns if is not a shared memory volume.

--- a/guidebooks/ml/ray/start/kubernetes/chart/values.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/chart/values.yaml
@@ -7,6 +7,10 @@ mcad:
   scheduler: default # use the default kubernetes pod scheduler
   # scheduler: coscheduler # https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/coscheduling/README.md
 
+failsafes:
+  ray:
+    version: 1.13.0
+  
 # Default values for Ray.
 
 # RayCluster settings:

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
@@ -11,9 +11,9 @@ SUBDIR=deploy/charts/ray
 if [ "$KUBE_POD_MANAGER" = mcad ] || [ "$KUBE_POD_MANAGER" = kubernetes ]; then
     # MCAD-enabled helm chart; this chart also allows mcad-free operation, hence the ||
     GITHUB=github.com
-    ORG=guidebooks
-    REPO=store
-    BRANCH=""
+    ORG=${RAY_CHART_ORG-guidebooks}
+    REPO=${RAY_CHART_REPO-store}
+    BRANCH=${RAY_CHART_BRANCH}
     SUBDIR=guidebooks/ml/ray/start/kubernetes/chart
 
     if [ "$KUBE_POD_MANAGER" = mcad ]


### PR DESCRIPTION
This should allow use of lightweight images, such as `python:3.8-slim`. The head and worker nodes will detect the absence of the `ray` pip, and install it if needed.

This PR also:

- adds a missing readiness probe to the ray helm chart's head container
- allows the helm chart REPO, ORG, and BRANCH to be specified by env vars: RAY_CHART_ORG, etc.