### PR TITLE
fix: increase pod readiness wait timeout in ml/ray/start/kubernetes

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -53,7 +53,7 @@ while true; do
     sleep 1
 done
 
-kubectl wait pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_RAY_HEAD_LABEL_SELECTOR} --for=condition=Ready && \
+kubectl wait pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_RAY_HEAD_LABEL_SELECTOR} --for=condition=Ready --timeout=240s && \
     echo "Head node is ready"
 ```
 
@@ -67,6 +67,6 @@ while true; do
     sleep 1
 done
 
-kubectl wait pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_LABEL_SELECTOR} --for=condition=Ready && \
+kubectl wait pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_LABEL_SELECTOR} --for=condition=Ready --timeout=240s && \
     echo "Worker node is ready"
 ```


### PR DESCRIPTION
We were using the default of 30s; this PR increases the wait timeout to 240s