### PR TITLE
fix: allow in-cluster operation to specify a default context and namespace name

### DIFF
--- a/guidebooks/kubernetes/choose/ns.md
+++ b/guidebooks/kubernetes/choose/ns.md
@@ -14,14 +14,16 @@ same, but in a restricted environment, a Project can act as a
 Namespace, without the additional security concerns that Namespaces
 bring.
 
-=== "expand([ -z ${KUBE_CONTEXT} ] && exit 1 || X=$(kubectl ${KUBE_CONTEXT_ARG} get ns -o name || oc ${KUBE_CONTEXT_ARG} get projects -o name); echo "$X" | sed -E 's#(namespace|project\.project\.openshift\.io)/##' | grep -Ev 'openshift|kube-', Kubernetes namespaces)"
+=== "expand([ -z ${KUBE_CONTEXT} ] && exit 1 || X=$([ -n "$KUBE_NS_FOR_TEST" ] && echo $KUBE_NS_FOR_TEST || kubectl ${KUBE_CONTEXT_ARG} get ns -o name || oc ${KUBE_CONTEXT_ARG} get projects -o name); echo "$X" | sed -E 's#(namespace|project\.project\.openshift\.io)/##' | grep -Ev 'openshift|kube-', Kubernetes namespaces)"
     ```shell
     export KUBE_NS=${choice}
     ```
 
     ```shell
-    export KUBE_NS_ARG="-n ${choice}"
+    export KUBE_NS_ARG=$([ -n "$KUBE_NS_FOR_TEST" ] && echo "" || echo "-n ${choice}")
     ```
+
+    > If we are faking a project for tests, then don't use a `-n <namespace` CLI argument for subsequent `kubectl` commands.
 
 === "Create a namespace"
     ```shell

--- a/guidebooks/kubernetes/context.md
+++ b/guidebooks/kubernetes/context.md
@@ -9,17 +9,17 @@ A Kubernetes
 [context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 defines access to a cluster as a particular user.
 
-=== "expand((kubectl config get-contexts -o name | grep -E . >& /dev/null && kubectl config get-contexts -o name) || (kubectl version | grep Server >& /dev/null && echo "In-cluster" || exit 1), Kubernetes contexts)"
+=== "expand((kubectl config get-contexts -o name | grep -E . >& /dev/null && kubectl config get-contexts -o name) || (kubectl version | grep Server >& /dev/null && echo "${KUBE_CONTEXT_FOR_TEST-In-cluster}" || exit 1), Kubernetes contexts)"
     ```shell
     export KUBE_CONTEXT="${choice}"
     ```
 
     ```shell
-    export KUBE_CONTEXT_ARG="--context ${choice}"
+    export KUBE_CONTEXT_ARG=$([ -n "$KUBE_CONTEXT_FOR_TEST" ] && echo "" || echo "--context ${choice}")
     ```
 
     ```shell
-    export KUBE_CONTEXT_ARG_HELM="--kube-context ${choice}"
+    export KUBE_CONTEXT_ARG_HELM=$([ -n "$KUBE_CONTEXT_FOR_TEST" ] && echo "" || echo "--kube-context ${choice}")
     ```
 
 > The bit of complexity here is intended to handle the situation of


### PR DESCRIPTION
this helps with testing, so that the test rig can specify the in-cluster context and namespace strings; in-cluster, these strings are arbitrary