### PR TITLE
fix: allow splicing in of namespace in ray helm chart

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
@@ -36,16 +36,17 @@ fi
 
 # sparse clone
 if [ -n "$BRANCH" ]; then BRANCHOPT="-b $BRANCH"; fi
-(git clone -q --filter=tree:0 --depth 1 --sparse https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} >& /dev/null && \
+echo "Cloning https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT}"
+(git clone -q --filter=tree:0 --depth 1 --sparse https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} > /dev/null && \
     cd $REPO && \
-    git sparse-checkout init --cone >& /dev/null && \
-    git sparse-checkout set $SUBDIR >& /dev/null)
+    git sparse-checkout init --cone > /dev/null && \
+    git sparse-checkout set $SUBDIR > /dev/null)
 
 if [ "$KUBE_POD_MANAGER" = ray ]; then
     sed -i '' -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' $REPO/$SUBDIR/templates/*.yaml
 fi
 
-echo "$(tput setaf 4)Creating ray cluster num_cpus=$(tput setaf 5)${NUM_CPUS-1} $(tput setaf 4)num_gpus=$(tput setaf 5)${NUM_GPUS-1} $(tput setaf 4)head_memory=$(tput setaf 5)${HEAD_MEMORY-1Gi} $(tput setaf 4)worker_memory=$(tput setaf 5)${WORKER_MEMORY-1Gi} $(tput setaf 4)minWorkers=$(tput setaf 5)${MIN_WORKERS-2} $(tput setaf 4)maxWorkers=$(tput setaf 5)${MAX_WORKERS-3} $(tput setaf 4)image=$(tput setaf 5)${RAY_IMAGE} $(tput setaf 4)operatorImage=$(tput setaf 5)${RAY_OPERATOR_IMAGE} $(tput setaf 4)context=$(tput setaf 5)${KUBE_CONTEXT} $(tput setaf 4)namespace=$(tput setaf 5)${KUBE_NS}$(tput sgr0) $(tput setaf 4)clusterOnly=$(tput setaf 5)${CLUSTER_ONLY}$(tput sgr0)"
+echo "$(tput setaf 4)Creating ray cluster num_cpus=$(tput setaf 5)${NUM_CPUS-1} $(tput setaf 4)num_gpus=$(tput setaf 5)${NUM_GPUS-1} $(tput setaf 4)head_memory=$(tput setaf 5)${HEAD_MEMORY-1Gi} $(tput setaf 4)worker_memory=$(tput setaf 5)${WORKER_MEMORY-1Gi} $(tput setaf 4)minWorkers=$(tput setaf 5)${MIN_WORKERS-2} $(tput setaf 4)maxWorkers=$(tput setaf 5)${MAX_WORKERS-3} $(tput setaf 4)image=$(tput setaf 5)${RAY_IMAGE} $(tput setaf 4)operatorImage=$(tput setaf 5)${RAY_OPERATOR_IMAGE} $(tput setaf 4)context="$(tput setaf 5)${KUBE_CONTEXT_ARG_HELM}" $(tput setaf 4)namespace="$(tput setaf 5)${KUBE_NS_ARG}$(tput sgr0)" $(tput setaf 4)clusterOnly=$(tput setaf 5)${CLUSTER_ONLY}$(tput sgr0)"
 
 # sigh, ray's --num-cpus flag does not understand millicores, such as 250m, nor fractional cores at all
 # this maps 250m => 1 and 2500m => 3 and 4 => 4
@@ -59,7 +60,7 @@ cd $REPO/$SUBDIR && \
     helm upgrade --install --wait --timeout 30m ${RAY_KUBE_CLUSTER_NAME} . \
          ${KUBE_CONTEXT_ARG_HELM} ${KUBE_NS_ARG} \
          ${CREATE_NAMESPACE} ${STARTUP_PROBE} ${OPERATOR_IMAGE} \
-         --set clusterNamespace=${KUBE_NS} \
+         --set clusterNamespace=${KUBE_NS_FOR_REAL-${KUBE_NS}} \
          --set podTypes.rayHeadType.CPU=${NUM_CPUS-1} \
          --set podTypes.rayHeadType.CPUInteger=${NUM_CPUS_INTEGER-1} \
          --set podTypes.rayHeadType.memory=${HEAD_MEMORY-1Gi} \


### PR DESCRIPTION
Oof, mcad currently has a bug that forces us to state explicitly the target namespace in all of our resources. When running in-cluster, it may be difficult to intuit this name, especially under test scenarios (where, in order to use a fixed namespace for the guidebook profile (the answer to the "namespace" question).

This PR allows clients to set a KUBE_NS_FOR_REAL env var that will be used just for this scenario. Once mcad fixes its bug, i think we can back this out.