### PR TITLE
fix: add nodes to the log aggregator Role

### DIFF
--- a/guidebooks/ml/ray/aggregator/in-cluster/client-side/aggregator.yaml
+++ b/guidebooks/ml/ray/aggregator/in-cluster/client-side/aggregator.yaml
@@ -9,7 +9,7 @@ metadata:
   name: guidebook-log-aggregator-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "pods/exec", "services"]
+  resources: ["pods", "pods/exec", "services", "nodes"]
   verbs: ["events", "get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods/exec"]


### PR DESCRIPTION
so that ml/ray/run/node-stats works