### PR TITLE
fix: disable node-stats.sh collection in log aggregator

### DIFF
--- a/guidebooks/ml/ray/aggregator/in-cluster/client-side/aggregator.yaml
+++ b/guidebooks/ml/ray/aggregator/in-cluster/client-side/aggregator.yaml
@@ -9,7 +9,7 @@ metadata:
   name: guidebook-log-aggregator-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "pods/exec", "services", "nodes"]
+  resources: ["pods", "pods/exec", "services"]
   verbs: ["events", "get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods/exec"]

--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -5,7 +5,6 @@ We will stream out a suite of data, including resource utilization metrics and j
 ## Stream Resource Metrics
 
 --8<-- "./pod-stats.md"
---8<-- "./node-stats.md"
 --8<-- "./gpu-utilization.md"
 
 ## Capture Job Definition


### PR DESCRIPTION
This requires cluster scope privileges, which for not we should not assume.