### PR TITLE
fix: two more fixes for log aggregator not waiting long enough

### DIFF
--- a/guidebooks/ml/ray/aggregator/in-cluster/server-side/setup.md
+++ b/guidebooks/ml/ray/aggregator/in-cluster/server-side/setup.md
@@ -19,7 +19,7 @@ while true; do
     sleep 1
 done
 
-kubectl wait pod -l ray-node-type=head --for=condition=Ready
+kubectl wait pod -l ray-node-type=head --for=condition=Ready --timeout=240s
 ```
 
 Extract the name of the Ray cluster.

--- a/guidebooks/ml/ray/aggregator/setup.md
+++ b/guidebooks/ml/ray/aggregator/setup.md
@@ -22,7 +22,13 @@ export JOB_ENV=$(
         echo "Please set RAY_ADDRESS"
         exit 1
     else
-        echo $(curl -s $RAY_ADDRESS/api/jobs/$JOB_ID)
+        while true; do
+            resp=$(curl -s $RAY_ADDRESS/api/jobs/$JOB_ID)
+            if [ -n "$resp" ]
+            then echo "[Log Aggregator]: Ray job has started"; break;
+            else echo "[Log Aggregator]: Waiting for Ray job to start"; sleep 2;
+            fi
+        done
     fi
 )
 ```


### PR DESCRIPTION
1) head node wait should specify the same timeout we use elsewhere (240s); the default is 30s
2) server-side also needs to wait for the job to start before proceeding