### PR TITLE
fix: pin ray (to 1.13)

### DIFF
--- a/guidebooks/ml/codeflare/tuning/glue/pip.txt
+++ b/guidebooks/ml/codeflare/tuning/glue/pip.txt
@@ -1,5 +1,5 @@
 boto3
-ray[default]
+ray[default]==1.13
 ray_lightning
 pytorch_lightning
 torchvision

--- a/guidebooks/ml/ray/install/cli.md
+++ b/guidebooks/ml/ray/install/cli.md
@@ -4,7 +4,7 @@
 ---
 validate: which ray
 ---
-pip install -U "ray[default]"
+pip install -U "ray[default]==1.13"
 ```
 
 ```shell

--- a/guidebooks/ml/ray/start/local.md
+++ b/guidebooks/ml/ray/start/local.md
@@ -15,7 +15,7 @@ export PIP_LOCAL=true
     ---
     validate: pip-show ray
     ---
-    pip install -U "ray[default]"
+    pip install -U "ray[default]==1.13"
     ```
 
 === "Apple Silicon"


### PR DESCRIPTION
we have been floating our ray dependencies. 1.14 just came out with some breaking changes. we need to fix those, but we also need to avoid random breaking changes in the future. so, for now, we will pin to 1.13.