### PR TITLE
fix: restore ray cli-based log streaming

### DIFF
--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -54,5 +54,12 @@ consuming streaming output from that file "batchy". Instead, we use
 Ray API; for log following, this is a websocket protocol, hence the
 need for an additional tool. Sigh.
 
+### Logs just to console
+
+--8<-- "./logs/via-cli.md"
+
+### Logs to a file (and possibly the console, too)
+
 --8<-- "./logs/via-websocat.md"
 
+ 


### PR DESCRIPTION
oof, this caused a downstream regression. some paths actually still need the path that uses the ray cli to stream out job logs.

offending PR: https://github.com/guidebooks/store/pull/345
Rather than reverting that commit, we will patch back in the logic, since there was a useful change in that PR.