### PR TITLE
fix: allow roberta github location defaults to be overridden

### DIFF
--- a/guidebooks/ml/codeflare/training/roberta/index.md
+++ b/guidebooks/ml/codeflare/training/roberta/index.md
@@ -28,23 +28,23 @@ export ML_CODEFLARE_ROBERTA_WORKDIR=$(mktemp -d)
 ```
 
 ```shell
-export ML_CODEFLARE_ROBERTA_GITHUB=github.ibm.com
+export ML_CODEFLARE_ROBERTA_GITHUB=${ML_CODEFLARE_ROBERTA_GITHUB-github.ibm.com}
 ```
 
 ```shell
-export ML_CODEFLARE_ROBERTA_ORG=ai-foundation
+export ML_CODEFLARE_ROBERTA_ORG=${ML_CODEFLARE_ROBERTA_ORG-ai-foundation}
 ```
 
 ```shell
-export ML_CODEFLARE_ROBERTA_REPO=foundation-model-stack
+export ML_CODEFLARE_ROBERTA_REPO=${ML_CODEFLARE_ROBERTA_REPO-foundation-model-stack}
 ```
 
 ```shell
-export ML_CODEFLARE_ROBERTA_BRANCH=0-0-x
+export ML_CODEFLARE_ROBERTA_BRANCH=${ML_CODEFLARE_ROBERTA_BRANCH-0-0-x}
 ```
 
 ```shell
-export ML_CODEFLARE_ROBERTA_SUBDIR=RoBERTa/training
+export ML_CODEFLARE_ROBERTA_SUBDIR=${ML_CODEFLARE_ROBERTA_SUBDIR-RoBERTa/training}
 ```
 
 Clone the code.


### PR DESCRIPTION
- ML_CODEFLARE_ROBERTA_GITHUB
- ML_CODEFLARE_ROBERTA_ORG
- ML_CODEFLARE_ROBERTA_REPO
- ML_CODEFLARE_ROBERTA_BRANCH
- ML_CODEFLARE_ROBERTA_SUBDIR

where the git clone looks like:

```
git@${ML_CODEFLARE_ROBERTA_GITHUB}:${ML_CODEFLARE_ROBERTA_ORG}/${ML_CODEFLARE_ROBERTA_REPO}.git
```

or will look like this, if two additional env vars are defined (ML_CODEFLARE_ROBERTA_GITHUB_USER, ML_CODEFLARE_ROBERTA_GITHUB_TOKEN):

```
https://${ML_CODEFLARE_ROBERTA_GITHUB_USER}:${ML_CODEFLARE_ROBERTA_GITHUB_TOKEN}@${ML_CODEFLARE_ROBERTA_GITHUB}/${ML_CODEFLARE_ROBERTA_ORG}/${ML_CODEFLARE_ROBERTA_REPO}.git
```