### PR TITLE
fix: add a marker to the end of the getting-started guidebook

### DIFF
--- a/guidebooks/ml/codeflare/training/demos/getting-started/main.py
+++ b/guidebooks/ml/codeflare/training/demos/getting-started/main.py
@@ -48,3 +48,6 @@ model.fit(x=x_train,
           epochs=5, 
           validation_data=(x_test, y_test), 
           callbacks=[tensorboard_callback])
+
+# Helps with tests # @starpit
+print("Final result") # @starpit


### PR DESCRIPTION
Helps with tests