### PR TITLE
feat: associate ray head pod with a serviceaccount

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -32,6 +32,8 @@ spec:
         pod-group.scheduling.sigs.k8s.io: {{ include "ray.podgroup" . }}
         {{ end }}
     spec:
+      serviceAccountName: ray-head-serviceaccount
+
       {{ if eq .Values.mcad.scheduler "coscheduler" }}
       schedulerName: scheduler-plugins-scheduler
       {{ end }}

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/head-serviceaccount.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/head-serviceaccount.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ray-head-serviceaccount
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ray-head-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ray-head-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: ray-head-serviceaccount
+roleRef:
+  kind: Role
+  name: ray-head-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
To allow the head pod to list worker pods