### PR TITLE
fix: ml/ray/start/kubernetes/port-forward/ray should retry

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/port-forward/ray.md
+++ b/guidebooks/ml/ray/start/kubernetes/port-forward/ray.md
@@ -1,7 +1,6 @@
 ---
 imports:
     - util/shuf
-    - kubernetes/context
     - kubernetes/choose/ns
 ---
 
@@ -10,8 +9,14 @@ imports:
 To facilitate communication to the Ray API.
 
 ```shell.async
-kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/${RAY_KUBE_CLUSTER_NAME-mycluster}-ray-head ${RAY_KUBE_PORT-8266}:8265 > /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster}
+while true; do
+    kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/${RAY_KUBE_CLUSTER_NAME-mycluster}-ray-head ${RAY_KUBE_PORT-8266}:8265 > /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} || sleep 1
+done
 ```
+
+> Note: We loop here, because the client side connection to the server
+> will inevitably time out. The sleep is there to protect us from
+> unforeseen bugs that might otherwise result in an infinite spin loop.
 
 ### Wait for the ray port forwarder to become active
 

--- a/guidebooks/ml/ray/stop/kubernetes.md
+++ b/guidebooks/ml/ray/stop/kubernetes.md
@@ -1,9 +1,8 @@
 ---
 imports:
-    - ../../../kubernetes/kubectl.md
-    - ../../../kubernetes/context.md
-    - ../../../kubernetes/choose/ns.md
-    - ../../../kubernetes/helm3.md
+    - kubernetes/helm3
+    - kubernetes/kubectl
+    - kubernetes/choose/ns
 ---
 
 # Stop Ray in your Kubernetes Cluster


### PR DESCRIPTION
This PR adds a loop around the port forward, because the client side connection to the server will inevitably time out. The sleep is there to protect us from unforeseen bugs that might otherwise result in an infinite spin loop.

It also includes some minor cleanups to the imports.