### PR TITLE
fix: allow ray workers to use as much cpu as they need, if available

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
@@ -54,7 +54,6 @@ spec:
             cpu: {{ .Values.podTypes.rayWorkerType.CPU }}
             memory: {{ .Values.podTypes.rayWorkerType.memory }}
           limits:
-            cpu: {{ .Values.podTypes.rayWorkerType.CPU }}
             # The maximum memory that this pod is allowed to use. The
             # limit will be detected by ray and split to use 10% for
             # redis, 30% for the shared memory object store, and the


### PR DESCRIPTION
i.e. remove the cpu limit from the ray worker deployment