### PR TITLE
fix: kubectl context and namespace args have to be after verb

### DIFF
--- a/guidebooks/kubernetes/choose/ns.md
+++ b/guidebooks/kubernetes/choose/ns.md
@@ -14,7 +14,7 @@ same, but in a restricted environment, a Project can act as a
 Namespace, without the additional security concerns that Namespaces
 bring.
 
-=== "expand([ -z ${KUBE_CONTEXT} ] && exit 1 || X=$([ -n "$KUBE_NS_FOR_TEST" ] && echo $KUBE_NS_FOR_TEST || kubectl ${KUBE_CONTEXT_ARG} get ns -o name || oc ${KUBE_CONTEXT_ARG} get projects -o name); echo "$X" | sed -E 's#(namespace|project\.project\.openshift\.io)/##' | grep -Ev 'openshift|kube-', Kubernetes namespaces)"
+=== "expand([ -z ${KUBE_CONTEXT} ] && exit 1 || X=$([ -n "$KUBE_NS_FOR_TEST" ] && echo $KUBE_NS_FOR_TEST || kubectl get ${KUBE_CONTEXT_ARG} ns -o name || oc ${KUBE_CONTEXT_ARG} get projects -o name); echo "$X" | sed -E 's#(namespace|project\.project\.openshift\.io)/##' | grep -Ev 'openshift|kube-', Kubernetes namespaces)"
     ```shell
     export KUBE_NS=${choice}
     ```

--- a/guidebooks/ml/mlflow/start/kubernetes/install.md
+++ b/guidebooks/ml/mlflow/start/kubernetes/install.md
@@ -18,7 +18,7 @@ export S3_BUCKETMLFLOW=${S3_BUCKETRAYLOGS}/mlflow
 ```shell
 ---
 validate: |
-  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} get deploy mlflow; else exit 1; fi
+  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then kubectl get ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} deploy mlflow; else exit 1; fi
 ---
 --8<-- "./install.sh"
 ```

--- a/guidebooks/ml/mlflow/start/kubernetes/port-forward.md
+++ b/guidebooks/ml/mlflow/start/kubernetes/port-forward.md
@@ -14,7 +14,7 @@ export MLFLOW_PORT=${MLFLOW_PORT-$(shuf -i 8266-9999 -n1)}
 ```
 
 ```shell.async
-kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/mlflow-service ${MLFLOW_PORT}:9080 > /tmp/port-forward-mlflow
+kubectl port-forward ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} service/mlflow-service ${MLFLOW_PORT}:9080 > /tmp/port-forward-mlflow
 ```
 
 ```shell

--- a/guidebooks/ml/ray/cluster/kubernetes/is-ready.md
+++ b/guidebooks/ml/ray/cluster/kubernetes/is-ready.md
@@ -10,7 +10,7 @@ imports:
 # Ray-in-Kubernetes Cluster Readiness
 
 ```shell
-export RAY_MAX_WORKERS=$(kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} get raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} -o json | jq '.spec.podTypes | .[] | select(.name=="rayWorkerType") | .maxWorkers')
+export RAY_MAX_WORKERS=$(kubectl get ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} raycluster ${RAY_KUBE_CLUSTER_NAME-mycluster} -o json | jq '.spec.podTypes | .[] | select(.name=="rayWorkerType") | .maxWorkers')
 ```
 
 Emit the initial state

--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -27,7 +27,7 @@ kubectl get events ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} --watch-only | tee "${STRE
 ```shell.async
 if [ -n "$DEBUG_KUBERNETES" ]; then
     echo "Streaming out Ray Pod Logs"
-    kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} logs -l ray-cluster-name=${RAY_KUBE_CLUSTER_NAME} -f
+    kubectl logs ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ray-cluster-name=${RAY_KUBE_CLUSTER_NAME} -f
 fi
 ```
 

--- a/guidebooks/ml/tensorboard/start/kubernetes/install.md
+++ b/guidebooks/ml/tensorboard/start/kubernetes/install.md
@@ -18,7 +18,7 @@ export S3_BUCKETTENSORBOARD=${S3_BUCKETRAYLOGS}/tensorboard
 ```shell
 ---
 validate: |
-  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} get deploy tensorboard; else exit 1; fi
+  if [ -n "${KUBE_CONTEXT}" ] && [ -n "${KUBE_NS}" ]; then kubectl get ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} deploy tensorboard; else exit 1; fi
 ---
 --8<-- "./install.sh"
 ```

--- a/guidebooks/ml/tensorboard/start/kubernetes/port-forward.md
+++ b/guidebooks/ml/tensorboard/start/kubernetes/port-forward.md
@@ -14,7 +14,7 @@ export TENSORBOARD_PORT=${TENSORBOARD_PORT-$(shuf -i 8266-9999 -n1)}
 ```
 
 ```shell.async
-kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/tensorboard-service ${TENSORBOARD_PORT}:9080 > /tmp/port-forward-tensorboard
+kubectl port-forward ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} service/tensorboard-service ${TENSORBOARD_PORT}:9080 > /tmp/port-forward-tensorboard
 ```
 
 ```shell


### PR DESCRIPTION
we had a few cases of `kubectl --context foo get pods` (or some such); i'm not entirely sure, but i think that some versions of kubectl are not happy with options coming before the verb.