### PR TITLE
fix: if user selects "create namespace", then profile can get stuck

### DIFF
--- a/guidebooks/kubernetes/choose/ns.md
+++ b/guidebooks/kubernetes/choose/ns.md
@@ -27,6 +27,9 @@ bring.
 
 === "Create a namespace"
     ```shell
+    ---
+    validate: kubectl get ns madns
+    ---
     kubectl create ns madns
     ```
     


### PR DESCRIPTION
the `kubernetes/choose/ns` option to create a namespace is not validating that the namespace already exists