### PR TITLE
fix: improve git compatibility with sparse checkout

### DIFF
--- a/guidebooks/kubernetes/coscheduler/install/coscheduler.sh
+++ b/guidebooks/kubernetes/coscheduler/install/coscheduler.sh
@@ -14,10 +14,9 @@ echo "Installing Enhanced Scheduler Support"
 
 # sparse clone
 if [ -n "$BRANCH" ]; then BRANCHOPT="-b $BRANCH"; fi
-(git clone -q --filter=tree:0 --depth 1 --sparse https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} >& /dev/null && \
+(git clone -q --no-checkout --filter=blob:none https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} && \
     cd $REPO && \
-    git sparse-checkout init --cone >& /dev/null && \
-    git sparse-checkout set $SUBDIR >& /dev/null)
+    git sparse-checkout set $SUBDIR && git checkout main)
 
 cd $REPO/manifests/install/charts && \
     helm upgrade --install --wait scheduler-plugins as-a-second-scheduler/ \

--- a/guidebooks/kubernetes/mcad/install/mcad.sh
+++ b/guidebooks/kubernetes/mcad/install/mcad.sh
@@ -12,10 +12,9 @@ echo "Installing Advanced Pod Manager"
 
 # sparse clone
 if [ -n "$BRANCH" ]; then BRANCHOPT="-b $BRANCH"; fi
-(git clone -q --filter=tree:0 --depth 1 --sparse https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} > /dev/null && \
+(git clone -q --no-checkout --filter=blob:none https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} && \
     cd $REPO && \
-    git sparse-checkout init --cone > /dev/null && \
-    git sparse-checkout set $SUBDIR > /dev/null)
+    git sparse-checkout set --cone $SUBDIR && git checkout main)
 
 if [ -n "$CI" ]; then
     # If we are running in a CI setting, we need to dial down the

--- a/guidebooks/ml/codeflare/training/roberta/clone.sh
+++ b/guidebooks/ml/codeflare/training/roberta/clone.sh
@@ -27,7 +27,7 @@ fi
 # sparse clone
 if [ -n "$ML_CODEFLARE_ROBERTA_BRANCH" ]; then BRANCHOPT="-b $ML_CODEFLARE_ROBERTA_BRANCH"; fi
 echo "Cloning $URL ${BRANCHOPT}"
-(git clone -q --filter=tree:0 --depth 1 --sparse "$URL" ${BRANCHOPT} > /dev/null && \
+(git clone -q --no-checkout --filter=blob:none "$URL" ${BRANCHOPT} > /dev/null && \
     cd "$ML_CODEFLARE_ROBERTA_REPO" && \
     git sparse-checkout init --cone > /dev/null && \
     git sparse-checkout set "${ML_CODEFLARE_ROBERTA_SUBDIR}" > /dev/null)

--- a/guidebooks/ml/mlflow/start/kubernetes/install.sh
+++ b/guidebooks/ml/mlflow/start/kubernetes/install.sh
@@ -3,10 +3,9 @@ CHART_DIR=guidebooks/ml/mlflow/start/kubernetes/chart
 MLFLOW_CLONE_TEMPDIR=$(mktemp -d)
 cd $MLFLOW_CLONE_TEMPDIR
 
-git clone --filter=tree:0 --depth 1 --sparse https://github.com/guidebooks/store.git >& /dev/null && \
+git clone -q --no-checkout --filter=blob:none https://github.com/guidebooks/store.git && \
     cd store && \
-    git sparse-checkout init --cone >& /dev/null && \
-    git sparse-checkout set $CHART_DIR >& /dev/null
+    git sparse-checkout set --cone $CHART_DIR && git checkout main
 
 helm --kube-context ${KUBE_CONTEXT} -n ${KUBE_NS} \
      upgrade --install --wait --timeout 30m \

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
@@ -37,10 +37,9 @@ fi
 # sparse clone
 if [ -n "$BRANCH" ]; then BRANCHOPT="-b $BRANCH"; fi
 echo "Cloning https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT}"
-(git clone -c advice.detachedHead=false -q --filter=tree:0 --depth 1 --sparse https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} > /dev/null && \
+(git clone -q --no-checkout --filter=blob:none https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} > /dev/null && \
     cd $REPO && \
-    git sparse-checkout init --cone > /dev/null && \
-    git sparse-checkout set $SUBDIR > /dev/null)
+    git sparse-checkout set $SUBDIR && git checkout main)
 
 if [ "$KUBE_POD_MANAGER" = ray ]; then
     sed -i '' -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' $REPO/$SUBDIR/templates/*.yaml

--- a/guidebooks/ml/tensorboard/start/kubernetes/install.sh
+++ b/guidebooks/ml/tensorboard/start/kubernetes/install.sh
@@ -3,10 +3,9 @@ CHART_DIR=guidebooks/ml/tensorboard/start/kubernetes/chart
 TENSORBOARD_CLONE_TEMPDIR=$(mktemp -d)
 cd $TENSORBOARD_CLONE_TEMPDIR
 
-git clone --filter=tree:0 --depth 1 --sparse https://github.com/guidebooks/store.git >& /dev/null && \
+git clone -q --no-checkout --filter=blob:none https://github.com/guidebooks/store.git && \
     cd store && \
-    git sparse-checkout init --cone >& /dev/null && \
-    git sparse-checkout set $CHART_DIR >& /dev/null
+    git sparse-checkout set --cone $CHART_DIR && git checkout main
 
 helm --kube-context ${KUBE_CONTEXT} -n ${KUBE_NS} \
      upgrade --install --wait --timeout 30m \


### PR DESCRIPTION
ugh, it looks like git had a horrible bug in its git checkout --sparse when you use a url, and of course broken versions of git seem to be fairly common  — e.g. a broken version was installed in my ubuntu-on-WSL2 by default.

we were using git clone --sparse https://somethingsomething, which git 2.25 does not like. This PR switches us to a form that seems to work with 2.25 and later versions as well (2.37.x tested).

all of our automated tests apparently were using a version without this git bug.