### PR TITLE
fix: use pip3 rather than pip to install deps

### DIFF
--- a/guidebooks/ml/ray/install/cli.md
+++ b/guidebooks/ml/ray/install/cli.md
@@ -8,5 +8,5 @@ export PATH=~/.local/bin:$PATH:~/Library/Python/3.9/bin:~/Library/Python/3.8/bin
 ---
 validate: which ray
 ---
-which ray || pip install -U "ray[default]==1.13"
+(which ray >& /dev/null) || pip3 install -U "ray[default]==1.13"
 ```

--- a/guidebooks/ml/ray/install/data.md
+++ b/guidebooks/ml/ray/install/data.md
@@ -8,6 +8,6 @@ To get started with Ray Data, you will need to install a library.
 ---
 validate: pip-show ray[data]
 ---
-pip install "ray[data]" dask
+pip3 install -U "ray[data]" dask
 ```
 

--- a/guidebooks/ml/ray/install/serve.md
+++ b/guidebooks/ml/ray/install/serve.md
@@ -16,6 +16,6 @@ To get started with Ray Serve, you will need to install a library.
 ---
 validate: pip-show ray[serve]
 ---
-pip install "ray[serve]"
+pip3 install -U "ray[serve]"
 ```
 

--- a/guidebooks/ml/ray/install/tune.md
+++ b/guidebooks/ml/ray/install/tune.md
@@ -13,5 +13,5 @@ To get started with Ray Tune, you will need to install a library.
 ---
 validate: pip-show ray[tune]
 ---
-pip install "ray[tune]"
+pip3 install -U "ray[tune]"
 ```

--- a/guidebooks/ml/ray/start/local.md
+++ b/guidebooks/ml/ray/start/local.md
@@ -15,7 +15,7 @@ export PIP_LOCAL=true
     ---
     validate: pip-show ray
     ---
-    pip install -U "ray[default]==1.13"
+    pip3 install -U "ray[default]==1.13"
     ```
 
 === "Apple Silicon"
@@ -30,7 +30,7 @@ export PIP_LOCAL=true
     conda activate
     pip uninstall grpcio
     conda install grpcio
-    pip install ray
+    pip3 install -U "ray[default]==1.13"
     ```
         
 ```shell

--- a/guidebooks/python/pip/aiorwlock.md
+++ b/guidebooks/python/pip/aiorwlock.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show aiorwlock
 ---
-pip install aiorwlock
+pip3 install -U aiorwlock
 ```

--- a/guidebooks/python/pip/boto3.md
+++ b/guidebooks/python/pip/boto3.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show boto3
 ---
-pip install boto3
+pip3 install -U boto3
 ```

--- a/guidebooks/python/pip/fastapi.md
+++ b/guidebooks/python/pip/fastapi.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show fastapi
 ---
-pip install fastapi
+pip3 install -U fastapi
 ```

--- a/guidebooks/python/pip/pyarrow.md
+++ b/guidebooks/python/pip/pyarrow.md
@@ -18,5 +18,5 @@ based on the C++ implementation of Arrow.
 ---
 validate: pip-show pyarrow
 ---
-pip install pyarrow
+pip3 install -U pyarrow
 ```

--- a/guidebooks/python/pip/ray_lightning.md
+++ b/guidebooks/python/pip/ray_lightning.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show ray_lightning
 ---
-pip install ray_lightning
+pip3 install -U ray_lightning
 ```

--- a/guidebooks/python/pip/scikit-learn.md
+++ b/guidebooks/python/pip/scikit-learn.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show sklearn
 ---
-pip install scikit-learn
+pip3 install -U scikit-learn
 ```

--- a/guidebooks/python/pip/tabulate.md
+++ b/guidebooks/python/pip/tabulate.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show tabulate
 ---
-pip install tabulate
+pip3 install -U tabulate
 ```

--- a/guidebooks/python/pip/tensorboard.md
+++ b/guidebooks/python/pip/tensorboard.md
@@ -16,5 +16,5 @@ experimentation:
 ---
 validate: pip-show tensorboard
 ---
-pip install --user tensorboard
+pip3 install -U tensorboard
 ```

--- a/guidebooks/python/pip/tensorflow.md
+++ b/guidebooks/python/pip/tensorflow.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show tensorflow
 ---
-pip install --user tensorflow
+pip3 install -U tensorflow
 ```

--- a/guidebooks/python/pip/torch.md
+++ b/guidebooks/python/pip/torch.md
@@ -8,5 +8,5 @@ production deployment.
 ---
 validate: pip-show torch
 ---
-pip install torch
+pip3 install -U torch
 ```

--- a/guidebooks/python/pip/torch_lightning.md
+++ b/guidebooks/python/pip/torch_lightning.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show pytorch_lightning
 ---
-pip install pytorch_lightning
+pip3 install -U pytorch_lightning
 ```

--- a/guidebooks/python/pip/torchvision.md
+++ b/guidebooks/python/pip/torchvision.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show torchvision
 ---
-pip install torchvision
+pip3 install -U torchvision
 ```

--- a/guidebooks/python/pip/tqdm.md
+++ b/guidebooks/python/pip/tqdm.md
@@ -7,5 +7,5 @@ iterable with `tqdm(iterable)`, and you're done!
 ---
 validate: pip-show tqdm
 ---
-pip install tqdm
+pip3 install -U tqdm
 ```

--- a/guidebooks/python/pip/uvicorn.md
+++ b/guidebooks/python/pip/uvicorn.md
@@ -4,5 +4,5 @@
 ---
 validate: pip-show uvicorn
 ---
-pip install uvicorn
+pip3 install -U uvicorn
 ```


### PR DESCRIPTION
This should help us avoid issues with pip versus pip3, and thus avoid the need to install on linux (e.g.) python-is-python3

Also make sure to use --user consistently.