### PR TITLE
fix: pin openshift `oc` version to 4.10.33

### DIFF
--- a/guidebooks/openshift/oc.md
+++ b/guidebooks/openshift/oc.md
@@ -10,30 +10,34 @@ The `oc` CLI gives you command line access to your
 [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift)
 cluster.
 
+```shell
+export OPENSHIFT_CLI_VERSION=4.10.33
+```
+
 === "MacOS"
 
     === "Intel"
         ```shell
-        curl -s --retry 10 -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-mac.tar.gz | tar zxf - oc
+        curl -s --retry 10 -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_CLI_VERSION/openshift-client-mac.tar.gz | tar zxf - oc
         sudo mv oc /usr/local/bin
         ```
 
     === "Apple Silicon"
         ```shell
-        curl -s --retry 10 -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-mac-arm64.tar.gz | tar zxf - oc
+        curl -s --retry 10 -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_CLI_VERSION/openshift-client-mac-arm64.tar.gz | tar zxf - oc
         sudo mv oc /usr/local/bin
         ```
 
 === "Linux"
     ```shell
-    curl -s --retry 10 -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | tar zxf - oc
+    curl -s --retry 10 -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_CLI_VERSION/openshift-client-linux.tar.gz | tar zxf - oc
     sudo mv oc /usr/local/bin
     ```
 
 
 === "Win32"
     ```shell
-    curl -s --retry 10 -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-windows.zip
+    curl -s --retry 10 -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_CLI_VERSION/openshift-client-windows.zip
     unzip openshift-client-windows.zip oc
     ```
 


### PR DESCRIPTION
We had been floating "stable". The latest 4.11.5 does not work against clusters with untrusted certificates

> error: x509: "kube-apiserver-lb-signer" certificate is not trusted