### PR TITLE
fix: roberta with sample input should use /tmp for logdir

### DIFF
--- a/guidebooks/ml/codeflare/training/roberta/wrapper.sh
+++ b/guidebooks/ml/codeflare/training/roberta/wrapper.sh
@@ -8,7 +8,7 @@ if [ "$ML_CODEFLARE_ROBERTA_DATA" = "public" ]; then
     R_DATA_ENDPOINT=${ML_CODEFLARE_ROBERTA_S3_ENDPOINT_URL-s3.direct.us-east.cloud-object-storage.appdomain.cloud}
     R_DATA_BUCKET=${ML_CODEFLARE_ROBERTA_S3_BUCKET-codeflare-roberta-public}
     R_DATA_OBJECT=${ML_CODEFLARE_ROBERTA_S3_OBJECT-roberta-sample-input-0.0.1.tar.gz}
-    R_ARGS=${ML_CODEFLARE_ROBERTA_ARGS-"--simulated_gpus 4 --num_steps 100 --report_interval 10 --b_size 12"}
+    R_ARGS=${ML_CODEFLARE_ROBERTA_ARGS-"--simulated_gpus 4 --num_steps 100 --report_interval 10 --b_size 12 --logdir=/tmp/"}
     # ^^^ here we are using a quite conservative b_size, to allow for running on a 16GiB GPU
 else
     # bring your own data


### PR DESCRIPTION
Since the logdir isn't important for the sample run, let's use the path that has the highest chance of working versus permissions. The default in the roberta python code is currently /home/ray/ which might not be accessible in certain clusters.