### PR TITLE
fix: ml/ray/start/kubernetes expresses import dependencies that aren't directly needed

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -1,11 +1,8 @@
 ---
 imports:
     - kubernetes/kubectl
-    - kubernetes/helm3
-    - kubernetes/context
-    - kubernetes/choose/ns
-    - ./kubernetes/label-selectors
     - ./resources
+    - kubernetes/choose/ns
 ---
 
 # Install Ray on a Kubernetes Cluster

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.md
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.md
@@ -1,5 +1,7 @@
 ---
 imports:
+    - ./label-selectors
+    - kubernetes/helm3
     - ml/ray/cluster/kubernetes/choose-pod-scheduler
 ---
 


### PR DESCRIPTION
this PR moves those dependences down to install-via-helm