### PR TITLE
feat: bump to madwizard 1.0.0 which mandates use of imports versus inlining

### DIFF
--- a/guidebooks/ml/codeflare/index.md
+++ b/guidebooks/ml/codeflare/index.md
@@ -5,7 +5,8 @@
 ## What do you want to do today?
 
 === "Start a new Run"
-    --8<-- "./run.md"
+    I would like to configure and fire off a run.
+    :import{./run.md}
     
 === "Connect Dashboard to an existing Run"
     I would like to visualize the resource consumption, status, and logs of a run in progress.

--- a/guidebooks/ml/codeflare/run-with-codeflare.md
+++ b/guidebooks/ml/codeflare/run-with-codeflare.md
@@ -5,7 +5,7 @@ collection of optimized source code and pre-trained models that you
 can leverage to expedite your time to value.
 
 === "Training Tasks"
-    --8<-- "./training"
+    :import{./training}
 
 === "Fine Tuning Tasks"
-    --8<-- "./tuning"
+    :import{./tuning}

--- a/guidebooks/ml/codeflare/run.md
+++ b/guidebooks/ml/codeflare/run.md
@@ -5,11 +5,16 @@ I would like to configure and fire off a run.
 ## What kind of application do you want to run?
 
 === "Run with CodeFlare Model Architecture"
-    --8<-- "./run-with-codeflare.md"
     
+    The [CodeFlare](https://codeflare.dev) project offers a curated
+    collection of optimized source code and pre-trained models that you
+    can leverage to expedite your time to value.
+    :import{./run-with-codeflare.md}
+
 === "Bring Your Own Code"
-    --8<-- "./training/byoc/index.md"
+    This path provides a way for you to run your own custom code on a remote ray cluster.
+    :import{./training/byoc/index.md}
 
 === "Demos"
     Experience how CodeFlare integrates with Tensorboard, MLFlow, and other technologies on simple demo applications.
-    --8<-- "./training/demos/index.md"
+    :import{./training/demos/index.md}

--- a/guidebooks/ml/codeflare/training/demos/index.md
+++ b/guidebooks/ml/codeflare/training/demos/index.md
@@ -1,8 +1,8 @@
 === "Getting Started Demo"
-    --8<-- "./getting-started"
+    :import{./getting-started}
 
 === "MLFlow Demo"
-    --8<-- "./mlflow"
+    :import{./mlflow}
 
 === "Tensorboard Demo"
-    --8<-- "./tensorboard"
+    :import{./tensorboard}

--- a/guidebooks/ml/codeflare/training/index.md
+++ b/guidebooks/ml/codeflare/training/index.md
@@ -13,4 +13,4 @@ by the training process.
     is a robustly optimized method for pretraining natural language
     processing (NLP) systems.
 
-    --8<-- "./roberta"
+    :import{./roberta}

--- a/guidebooks/ml/codeflare/training/roberta/choose-data.md
+++ b/guidebooks/ml/codeflare/training/roberta/choose-data.md
@@ -15,4 +15,4 @@
     :import{s3/choose/object}
 
 === "My S3 data will be pre-mounted via s3fs"
-    --8<-- "./choose-data-s3fs"
+    :import{./choose-data-s3fs}

--- a/guidebooks/ml/codeflare/tuning/index.md
+++ b/guidebooks/ml/codeflare/tuning/index.md
@@ -7,4 +7,4 @@ same domain.
 ## Which fine-tuning application do you want to run?
 
 === "GLUE"
-    --8<-- "./glue"
+    :import{./glue}

--- a/guidebooks/ml/mlflow/start/index.md
+++ b/guidebooks/ml/mlflow/start/index.md
@@ -4,11 +4,6 @@
 ML lifecycle, including experimentation, reproducibility, deployment,
 and a central model registry.
 
-=== "Run Locally"
-    Run The MLFlow Server on your computer.
-    ```shell
-    echo TODO
-    ```
+Only Kubernetes is supported, for now.
 
-=== "Run on a Kubernetes Cluster"
-    --8<-- "./kubernetes"
+--8<-- "./kubernetes"

--- a/guidebooks/ml/ray/cluster/index.md
+++ b/guidebooks/ml/ray/cluster/index.md
@@ -1,7 +1,5 @@
 # Pick a Ray Target
 
-=== "My Cluster is Running Locally"
-    --8<-- "./local.md"
+Only Kubernetes is supported, for now.
 
-=== "My Cluster is Running on Kubernetes"
-    --8<-- "./kubernetes/index.md"
+--8<-- "./kubernetes/index.md"

--- a/guidebooks/ml/ray/run/core/index.md
+++ b/guidebooks/ml/ray/run/core/index.md
@@ -1,5 +1,5 @@
 === "Example: Using Ray Tasks to Parallelize a Function"
-    --8<-- "./tasks.md"
+    :import{./tasks}
 
 === "Example: Using Ray Actors to Parallelize a Class"
-    --8<-- "./actors.md"
+    :import{./actors}

--- a/guidebooks/ml/ray/run/data/create/index.md
+++ b/guidebooks/ml/ray/run/data/create/index.md
@@ -8,7 +8,7 @@ imports:
 --8<-- "../../glossary/dataset.md"
 
 === "New Dataset from Range"
-    --8<-- "./from-range.md"
+    :import{./from-range}
 
 === "New Dataset from File"
-    --8<-- "./from-file.md"
+    :import{./from-file}

--- a/guidebooks/ml/ray/run/data/index.md
+++ b/guidebooks/ml/ray/run/data/index.md
@@ -1,2 +1,2 @@
 === "Example: Creating and Transforming Datasets"
-    --8<-- "./create/index.md"
+    :import{./create}

--- a/guidebooks/ml/ray/run/index.md
+++ b/guidebooks/ml/ray/run/index.md
@@ -7,8 +7,8 @@ imports:
 
 # Run a Ray Job
 
---8<-- "./core/index.md"
---8<-- "./data/index.md"
---8<-- "./train/index.md"
---8<-- "./tune/index.md"
---8<-- "./serve/index.md"
+--8<-- "./core"
+--8<-- "./data"
+--8<-- "./train"
+--8<-- "./tune"
+--8<-- "./serve"

--- a/guidebooks/ml/ray/run/serve/index.md
+++ b/guidebooks/ml/ray/run/serve/index.md
@@ -1,2 +1,2 @@
 === "Example: Serving a scikit-learn gradient boosting classifier"
-    --8<-- "./examples/gradient-boosting.md"
+    :import{./examples/gradient-boosting}

--- a/guidebooks/ml/ray/run/train/examples/pytorch/index.md
+++ b/guidebooks/ml/ray/run/train/examples/pytorch/index.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - ../../../../../../python/pip/torch.md
+    - python/pip/torch
 ---
 
 # Ray Train with PyTorch

--- a/guidebooks/ml/ray/run/train/index.md
+++ b/guidebooks/ml/ray/run/train/index.md
@@ -1,3 +1,3 @@
 === "Example: Training Using PyTorch"
-    --8<-- "./examples/pytorch/index.md"
+    :import{./examples/pytorch/index.md}
 

--- a/guidebooks/ml/ray/run/tune/index.md
+++ b/guidebooks/ml/ray/run/tune/index.md
@@ -1,2 +1,2 @@
 === "Example: Hyperparameter Tuning"
-    --8<-- "./examples/grid-search.md"
+    :import{./examples/grid-search}

--- a/guidebooks/ml/ray/stop/index.md
+++ b/guidebooks/ml/ray/stop/index.md
@@ -1,7 +1,5 @@
 # Pick a Ray Target
 
-=== "Run Locally"
-    --8<-- "./local.md"
+Only Kubernetes is supported, for now.
 
-=== "Run on a Kubernetes Cluster"
-    --8<-- "./kubernetes.md"
+--8<-- "./kubernetes.md"

--- a/guidebooks/ml/tensorboard/start/index.md
+++ b/guidebooks/ml/tensorboard/start/index.md
@@ -2,11 +2,6 @@
 
 [Tensorboard](https://www.tensorflow.org/tensorboard/get_started#:~:text=TensorBoard%20is%20a%20tool%20for,dimensional%20space%2C%20and%20much%20more.) is a tool for providing the measurements and visualizations needed during the machine learning workflow. It enables tracking experiment metrics like loss and accuracy, visualizing the model graph, projecting embeddings to a lower dimensional space, and much more.
 
-=== "Run Locally"
-    Run The Tensorboard Server on your computer.
-    ```shell
-    echo TODO
-    ```
+Only Kubernetes is supported, for now.
 
-=== "Run on a Kubernetes Cluster"
-    --8<-- "./kubernetes"
+--8<-- "./kubernetes"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "madwizard": "*"
       },
       "peerDependencies": {
-        "madwizard": ">=0.19.5"
+        "madwizard": ">=1.0.0"
       }
     },
     "node_modules/@gar/promisify": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "madwizard": "*"
   },
   "peerDependencies": {
-    "madwizard": ">=0.19.5"
+    "madwizard": ">=1.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION


(not always, only for guidebooks that are importing other guidebooks that offer choice)