### PR TITLE
Enable users to change imagePullPolicy in the YAML file

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -53,7 +53,7 @@ spec:
       containers:
         - name: ray-head
           image: {{ .Values.image }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           command: [ "/bin/bash", "-c", "--" ]
           args:
             - {{ print "ray start --head --port=6379 --redis-shard-ports=6380,6381 --num-cpus=" .Values.podTypes.rayHeadType.CPUInteger " --num-gpus=" .Values.podTypes.rayHeadType.GPU " --object-manager-port=22345 --node-manager-port=22346 --dashboard-host=0.0.0.0 --block" }}

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
@@ -47,7 +47,7 @@ spec:
       containers:
       - name: ray-worker
         image: {{ .Values.image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/bash", "-c", "--"]
         args:
           - {{ print "ray start --num-cpus=" .Values.podTypes.rayWorkerType.CPUInteger " --num-gpus=" .Values.podTypes.rayWorkerType.GPU " --address=" (include "ray.headService" .) ":6379 --object-manager-port=22345 --node-manager-port=22346 --block" }}

--- a/guidebooks/ml/ray/start/kubernetes/chart/values.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/chart/values.yaml
@@ -31,6 +31,8 @@ failsafes:
 # It's recommended to build custom dependencies for your workload into this image,
 # taking one of the offical `rayproject/ray` images as base.
 image: rayproject/ray:latest
+# Define if images should be pulled or taken if present
+imagePullPolicy: IfNotPresent
 # If a node is idle for this many minutes, it will be removed.
 idleTimeoutMinutes: 5
 # serviceAccountName is used for the Ray head and each Ray worker.

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
@@ -14,7 +14,7 @@ if [ "$KUBE_POD_MANAGER" = mcad ] || [ "$KUBE_POD_MANAGER" = kubernetes ]; then
     ORG=${RAY_CHART_ORG-guidebooks}
     REPO=${RAY_CHART_REPO-store}
     BRANCH=${RAY_CHART_BRANCH-0.15.2} # <-- will get updated by @release-it/bumper; see top-level package.json
-    SUBDIR=guidebooks/ml/ray/start/kubernetes/chart
+    SUBDIR=${RAY_CHART_SUBDIR-guidebooks/ml/ray/start/kubernetes/chart}
 
     if [ "$KUBE_POD_MANAGER" = mcad ]
     then MCAD_ENABLED=true
@@ -77,4 +77,5 @@ cd $REPO/$SUBDIR && \
          --set operatorNamespace=${KUBE_NS} \
          ${startupProbe} \
          --set clusterOnly=${CLUSTER_ONLY-false} ${SKIP_CRDS} \
-         --set image=${RAY_IMAGE}
+         --set image=${RAY_IMAGE} \
+         --set imagePullPolicy=${IMAGE_PULL_POLICY}


### PR DESCRIPTION
This PR:
- Enables the user to change the `imagePullPolicy` value. In cases where the images have been update outside the cluster (and have the same tag used in the cluster), this will allow the image to be replaced with the newer version of the same image.
- Adds environment variable to specify the location of the RayChart if the default is not wanted