### PR TITLE
fix: update the terminology around choosing s3 credentials

### DIFF
--- a/guidebooks/s3/choose/instance-maybe.md
+++ b/guidebooks/s3/choose/instance-maybe.md
@@ -1,6 +1,8 @@
 --8<-- "./instance"
 
 === "My data is not stored in S3"
+
+    My application does not need access to S3 data.
     ```shell
     echo skipped
     ```

--- a/guidebooks/s3/choose/instance.md
+++ b/guidebooks/s3/choose/instance.md
@@ -1,13 +1,19 @@
-# Choose an S3 Provider
+# Help us to locate your S3 Credentials
 
-=== "AWS"
+=== "AWS-style"
+
+    My credentials are in ~/.aws/credentials. This does not mean that your S3 endpoint is in AWS, only that you are storing your S3 credentials on your laptop using [this convention](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
+
     ```shell
     export S3_PROVIDER=aws
     ```
 
     :import{aws/auth}
 
-=== "IBM"
+=== "IBM Cloud-style"
+    
+    I am using the "`ibmcloud cos`" CLI to manage my S3 credentials.
+
     ```shell
     export S3_PROVIDER=ibm
     ```


### PR DESCRIPTION
Instead of "my provider is aws", say "my credentials are stored on my laptop using the aws ~/.aws/credentials convention"