### PR TITLE
fix: workaround for madwizard bug in ml/codeflare/training/roberta/choose-data-public

### DIFF
--- a/guidebooks/ml/codeflare/training/roberta/choose-data.md
+++ b/guidebooks/ml/codeflare/training/roberta/choose-data.md
@@ -1,6 +1,7 @@
 # Choose Input Data for RoBERTa
 
 === "I want to run a quick test with sample data"
+
     --8<-- "./choose-data-public"
     
 === "I have my own input tar.gz file on S3"


### PR DESCRIPTION


tabs whose first paragraphs have links may appear truncated after that first link, if there is not a newline separating the tab from the body