### PR TITLE
fix: ml/ray/start/kubernetes/port-forward/ray causes cpu spinloop

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/port-forward/ray.md
+++ b/guidebooks/ml/ray/start/kubernetes/port-forward/ray.md
@@ -9,8 +9,12 @@ imports:
 To facilitate communication to the Ray API.
 
 ```shell.async
+N=1
+SLEEP=1
 while true; do
-    kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/${RAY_KUBE_CLUSTER_NAME-mycluster}-ray-head ${RAY_KUBE_PORT-8266}:8265 > /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} || sleep 1
+    kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward service/${RAY_KUBE_CLUSTER_NAME-mycluster}-ray-head ${RAY_KUBE_PORT-8266}:8265 > /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} || sleep $SLEEP
+    if [ "$N" -lt 10 ]; then SLEEP=10; fi
+    N=$((N + 1))
 done
 ```
 
@@ -21,5 +25,15 @@ done
 ### Wait for the ray port forwarder to become active
 
 ```shell
-while true; do if [ -f /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} ] && [ "$(cat /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} | grep -q 'Forwarding from' && echo 1 || echo 0)" = "1" ]; then break; sleep 1; fi; done
+N=1
+SLEEP=1
+while true; do 
+    if [ -f /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} ] && [ "$(cat /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} | grep -q 'Forwarding from' && echo 1 || echo 0)" = "1" ]; then
+      break
+    else
+      sleep 1
+    fi
+    if [ "$N" -lt 10 ]; then SLEEP=10; fi
+    N=$((N + 1))
+done
 ```


### PR DESCRIPTION
There was a typo in the script. The `sleep 1` was not being executed if the ray cluster was not reachable.