### PR TITLE
feat: bump default ray image to 2.1.0 (from 1.13.0)

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.md
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.md
@@ -10,11 +10,11 @@ imports:
 This defines the base docker image we will use for the ray head and worker nodes.
 
 ```shell
-export RAY_OPERATOR_IMAGE=${RAY_OPERATOR_IMAGE-rayproject/ray:1.13.1-py37}
+export RAY_OPERATOR_IMAGE=${RAY_OPERATOR_IMAGE-rayproject/ray:2.1.0-py37}
 ```
 
 ```shell
-export RAY_IMAGE=${RAY_IMAGE-$([ $NUM_GPUS = 0 ] && echo rayproject/ray:1.13.1-py37 || echo rayproject/ray-ml:1.13.1-py37-gpu)}
+export RAY_IMAGE=${RAY_IMAGE-$([ $NUM_GPUS = 0 ] && echo rayproject/ray:2.1.0 || echo rayproject/ray:2.1.0-gpu)}
 ```
 
 ```shell


### PR DESCRIPTION
BREAKING CHANGE: this is a major update to the ray api