### PR TITLE
feat: allow use of ibmcloud codeengine for kubernetes context selection

### DIFF
--- a/guidebooks/ibm/cloud/ce/project.md
+++ b/guidebooks/ibm/cloud/ce/project.md
@@ -20,10 +20,14 @@ are used to manage resources and provide access to its entities.
     ibmcloud ce project create --name myproject-${uuid}
     ```
 
-=== "expand(ibmcloud target | tail -1 | grep -qv "Not logged in" && ibmcloud ce project list -o json | jq -r '.[] | select(.state == \"active\")  | \"\\(.name) \\(.region_id)\"', Code Engine Projects)"
+=== "expand(ibmcloud target | tail -1 | grep -qv 'Not logged in' && ibmcloud ce project list -o json | jq -r '.[] | select(.state == \"active\")  | \"\\(.name) \\(.region_id)\"', Code Engine Projects)"
 
     ```shell
     export DESIRED_IBMCLOUD_REGION=$(echo "$choice" | awk '{print $2}')
+    ```
+
+    ```shell
+    export IBMCLOUD_CE_PROJECT=$(echo "$choice" | awk '{print $1}')
     ```
 
     ```shell
@@ -31,5 +35,9 @@ are used to manage resources and provide access to its entities.
     validate: ibmcloud ce project current | grep ${choice}
     ---
     ibmcloud target -r ${DESIRED_IBMCLOUD_REGION}
-    ibmcloud ce project target --name $(echo "$choice" | awk '{print $1}')
+    ibmcloud ce project target --name $IBMCLOUD_CE_PROJECT
+    ```
+    
+    ```shell
+    export KUBECONFIG=$(ibmcloud ce project current -o json | jq -r .kube_config_file)
     ```

--- a/guidebooks/ibm/cloud/target.md
+++ b/guidebooks/ibm/cloud/target.md
@@ -10,7 +10,7 @@ This guidebook helps you with targeting your [IBM
 Cloud](https://www.ibm.com/cloud) operations against a selected
 [resource group](https://cloud.ibm.com/docs/account?topic=account-rgs&interface=ui).
 
-=== "expand(ibmcloud target | tail -1 | grep -qv "Not logged in" && ibmcloud resource groups | grep ACTIVE | cut -d ' ' -f1, IBM Cloud Resource Groups)"
+=== "expand(ibmcloud target | tail -1 | grep -qv 'Not logged in' && ibmcloud resource groups | grep ACTIVE | cut -d ' ' -f1, IBM Cloud Resource Groups)"
 
     ```shell
     ibmcloud target -g "${choice}"

--- a/guidebooks/kubernetes/context.md
+++ b/guidebooks/kubernetes/context.md
@@ -22,6 +22,8 @@ defines access to a cluster as a particular user.
     export KUBE_CONTEXT_ARG_HELM=$([ -n "$KUBE_CONTEXT_FOR_TEST" ] && echo "" || echo "--kube-context ${choice}")
     ```
 
+--8<-- "./hosted-kubernetes"
+
 > The bit of complexity here is intended to handle the situation of
 > running a guidebook in a Pod running. In this case, the normal context
 > list is empty, but `kubectl` still works as desired. Hence, we first

--- a/guidebooks/kubernetes/hosted-kubernetes.md
+++ b/guidebooks/kubernetes/hosted-kubernetes.md
@@ -1,0 +1,24 @@
+=== "Use IBM Cloud CodeEngine"
+
+    The [Code Engine](https://cloud.ibm.com/docs/codeengine) service offers a hosted Kubernetes context.
+    :import{ibm/cloud/ce/project}
+    
+    ```shell
+    export KUBE_CONTEXT=$(kubectl config current-context)
+    ```
+
+    ```shell
+    export KUBE_CONTEXT_ARG="--context ${KUBE_CONTEXT}"
+    ```
+
+    ```shell
+    export KUBE_CONTEXT_ARG_HELM="--kube-context ${KUBE_CONTEXT}"
+    ```
+
+    ```shell
+    export KUBERNETES_RBAC_ENABLED=false
+    ```
+    
+    ```shell
+    export IMAGE_PULL_POLICY=Always
+    ```

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/head-serviceaccount.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/head-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -26,3 +27,4 @@ roleRef:
   kind: Role
   name: ray-head-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/guidebooks/ml/ray/start/kubernetes/chart/values.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/chart/values.yaml
@@ -7,6 +7,10 @@ mcad:
   scheduler: default # use the default kubernetes pod scheduler
   # scheduler: coscheduler # https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/coscheduling/README.md
 
+# properties of your kubernetes cluster viz. RBAC
+rbac:
+  enabled: true
+
 startupProbe:
   periodSeconds: 10
   failureThrehsold: 10
@@ -57,6 +61,7 @@ podTypes:
         # GPU is the number of NVIDIA GPUs used by this pod type.
         # (Optional, requires GPU nodes with appropriate setup. See https://docs.ray.io/en/master/cluster/kubernetes-gpu.html)
         GPU: 0
+        storage: 5Gi
         # rayResources is an optional string-int mapping signalling additional resources to Ray.
         # "CPU", "GPU", and "memory" are filled automatically based on the above settings, but can be overriden;
         # For example, rayResources: {"CPU": 0} can be used in the head podType to prevent Ray from scheduling tasks on the head.
@@ -91,6 +96,7 @@ podTypes:
         # GPU is the number of NVIDIA GPUs used by this pod type.
         # (Optional, requires GPU nodes with appropriate setup. See https://docs.ray.io/en/master/cluster/kubernetes-gpu.html)
         GPU: 0
+        storage: 5Gi
         # rayResources is an optional string-int mapping signalling additional resources to Ray.
         # "CPU", "GPU", and "memory" are filled automatically based on the above settings, but can be overriden;
         # For example, rayResources: {"CPU": 0} can be used in the head podType to prevent Ray from scheduling tasks on the head.

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
@@ -76,6 +76,7 @@ cd $REPO/$SUBDIR && \
          --set storage.path=${RAY_STORAGE_PATH-/tmp} \
          --set namespacedOperator=true \
          --set operatorNamespace=${KUBE_NS} \
+         --set rbac.enabled=${KUBERNETES_RBAC_ENABLED-true} \
          ${startupProbe} \
          --set clusterOnly=${CLUSTER_ONLY-false} ${SKIP_CRDS} \
          --set image=${RAY_IMAGE} \


### PR DESCRIPTION
1) Revert ray helm charts from job back to deploy. Some hosted kubernetes do not support jobs.
2) codeengine request that request==limit
3) codeengine does not support binary units e.g. Gi, it only supports G
4) ImagePullPolicy must be Always :(