### PR TITLE
feat: ray cluster name should vary by job

### DIFF
--- a/guidebooks/ml/codeflare/training/roberta/submit.md
+++ b/guidebooks/ml/codeflare/training/roberta/submit.md
@@ -41,6 +41,10 @@ export ML_CODEFLARE_ROBERTA_BRANCH=${ML_CODEFLARE_ROBERTA_BRANCH-0-0-x}
 export ML_CODEFLARE_ROBERTA_SUBDIR=${ML_CODEFLARE_ROBERTA_SUBDIR-RoBERTa/training}
 ```
 
+```shell
+export APP_NAME=roberta
+```
+
 Clone the code.
 ```shell
 --8<-- "./clone.sh"

--- a/guidebooks/ml/ray/cluster/choose/index.md
+++ b/guidebooks/ml/ray/cluster/choose/index.md
@@ -1,0 +1,3 @@
+# Select an Active Ray Cluster
+
+--8<-- "./kubernetes"

--- a/guidebooks/ml/ray/cluster/choose/kubernetes.md
+++ b/guidebooks/ml/ray/cluster/choose/kubernetes.md
@@ -1,0 +1,18 @@
+---
+imports:
+    - kubernetes/choose/ns
+---
+
+# Select an Active Ray Cluster Running in Kubernetes
+
+=== "expand(kubectl get ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} deploy -l type=ray -o name)"
+    ```shell
+    export RAY_KUBE_CLUSTER_NAME=$(kubectl get -n ray --no-headers ${choice} -o custom-columns=CLUSTER:.metadata.labels.ray-cluster-name)
+    ```
+
+=== "Nevermind, apparently I do not have any active Ray clusters"
+    No Ray clusters were found.
+    ```shell
+    # Indicate an realy exit to madwizard
+    exit 90
+    ```

--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 imports:
+    - util/jobid
     - kubernetes/kubectl
     - ./resources
     - kubernetes/choose/ns
@@ -12,7 +13,7 @@ This will install Ray on a Kubernetes context of your choosing.
 The name of the Ray Kubernetes Service:
 
 ```shell
-export RAY_KUBE_CLUSTER_NAME=${RAY_KUBE_CLUSTER_NAME-mycluster}
+export RAY_KUBE_CLUSTER_NAME=${RAY_KUBE_CLUSTER_NAME-ray-${APP_NAME-myapp}-${JOB_ID}}
 ```
 
 ## Stream out Events from the Ray Head Node

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -7,6 +7,7 @@ metadata:
   labels:
     component: ray-head
     type: ray
+    ray-cluster-name: {{ .Values.clusterName }}
     appwrapper.mcad.ibm.com: {{ .Values.clusterName }}
 spec:
   # Do not change this - Ray currently only supports one head node per cluster.

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
@@ -60,6 +60,7 @@ cd $REPO/$SUBDIR && \
          ${KUBE_CONTEXT_ARG_HELM} ${KUBE_NS_ARG} \
          ${CREATE_NAMESPACE} ${STARTUP_PROBE} ${OPERATOR_IMAGE} \
          ${HELM_EXTRA} \
+         --set clusterName=${RAY_KUBE_CLUSTER_NAME} \
          --set clusterNamespace=${KUBE_NS_FOR_REAL-${KUBE_NS}} \
          --set podTypes.rayHeadType.CPU=${NUM_CPUS-1} \
          --set podTypes.rayHeadType.CPUInteger=${NUM_CPUS_INTEGER-1} \

--- a/guidebooks/ml/ray/stop/kubernetes.md
+++ b/guidebooks/ml/ray/stop/kubernetes.md
@@ -3,10 +3,11 @@ imports:
     - kubernetes/helm3
     - kubernetes/kubectl
     - kubernetes/choose/ns
+    - ml/ray/cluster/choose
 ---
 
 # Stop Ray in your Kubernetes Cluster
 
 ```shell
-helm ${KUBE_CONTEXT_ARG_HELM} ${KUBE_NS_ARG} uninstall ${RAY_KUBE_CLUSTER_NAME-mycluster} || exit 0
+helm ${KUBE_CONTEXT_ARG_HELM} ${KUBE_NS_ARG} uninstall ${RAY_KUBE_CLUSTER_NAME} || exit 0
 ```


### PR DESCRIPTION
We had been using a fixed name for the ray cluster. This was fine before we tore down the ray cluster upon job completion. Now that we do so, we will need to use a variable ray cluster name (and helm chart name) per job.