### PR TITLE
feat: allow use of minio for ray workflows [DO NOT MERGE]

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -56,12 +56,12 @@ spec:
         - name: ray-head
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          command: [ "/bin/bash", "-c", "--" ]
           {{ if .Values.storage.secret }}
           envFrom:
             - secretRef:
                 name: {{ .Values.storage.secret }}
           {{- end }}
+          command: [ "/bin/bash", "-c", "--" ]
           args:
             - {{ print "ray start --head --port=6379 --redis-shard-ports=6380,6381 --num-cpus=" .Values.podTypes.rayHeadType.CPUInteger " --num-gpus=" .Values.podTypes.rayHeadType.GPU " --object-manager-port=22345 --node-manager-port=22346 --dashboard-host=0.0.0.0 --storage=" .Values.storage.path " --block" }}
           ports:

--- a/guidebooks/ml/ray/storage/s3/index.md
+++ b/guidebooks/ml/ray/storage/s3/index.md
@@ -1,0 +1,14 @@
+# Configure S3 for use with Ray Workflows
+
+=== "Use MinIO"
+
+    To set up a [MinIO](https://minio.io/) S3 service within your cluster just for use with Ray Workflows, select this option.
+    :import{./minio}
+    :import{./kubernetes/secret}
+
+=== "Use my Cloud provider for S3"
+    If you would like to use AWS or your own provider for S3, select this option.
+
+    :import{s3/choose/bucket}
+    :import{./setenv}
+    :import{./kubernetes/secret}

--- a/guidebooks/ml/ray/storage/s3/kubernetes/secret.md
+++ b/guidebooks/ml/ray/storage/s3/kubernetes/secret.md
@@ -4,8 +4,10 @@ imports:
     - kubernetes/choose/ns
 ---
 
+# Create MinIO Kubernetes Secret for Ray Workflows
+
 ```shell
-export ML_RAY_STORAGE_S3_KUBERNETES_SECRET=ml.ray.s3.kubernetes.secret
+export ML_RAY_STORAGE_S3_KUBERNETES_SECRET=${ML_RAY_STORAGE_S3_KUBERNETES_SECRET-ml.ray.s3.kubernetes.secret}
 ```
 
 ```shell

--- a/guidebooks/ml/ray/storage/s3/maybe.md
+++ b/guidebooks/ml/ray/storage/s3/maybe.md
@@ -1,16 +1,11 @@
----
-imports:
----
-
 # Enable Ray Workflows?
 
-=== "My code uses Ray Workflows"
-    You will need to point to an S3 bucket, as Ray Workflows needs a durable place to store its state.
-    
-    :import{s3/choose/bucket}
-    :import{./setenv}
-    :import{./kubernetes/secret}
+=== "I need to configure S3 storage for Ray Workflows"
 
-=== "My code does not use Ray Workflows"
+    Choose this if your code uses [Ray Workflows](https://docs.ray.io/en/latest/workflows/management.html) **and** you want to run workflows across more than one node. In this case, Ray requires that you set up S3 storage to facilitate the communication between the workers. If you will running only against the Ray head node, with no additional workers, you will **not** need this.
+    
+    :import{./index}
+
+=== "My code does not need this"
 
     :import{./default}

--- a/guidebooks/ml/ray/storage/s3/minio/configure.md
+++ b/guidebooks/ml/ray/storage/s3/minio/configure.md
@@ -1,0 +1,9 @@
+# Configure MinIO for Ray Workflows
+
+```shell
+export S3_BUCKET=guidebooks
+```
+
+```shell
+kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} exec minio-client -- mc mb minio/${S3_BUCKET}
+```

--- a/guidebooks/ml/ray/storage/s3/minio/index.md
+++ b/guidebooks/ml/ray/storage/s3/minio/index.md
@@ -1,0 +1,9 @@
+---
+imports:
+    - ../minio/secret
+    - s3/minio/kubernetes/install
+    - ../minio/configure
+    - ../setenv
+---
+
+# Set up MinIO in your Kubernetes cluster for use with Ray Workflows

--- a/guidebooks/ml/ray/storage/s3/minio/secret.md
+++ b/guidebooks/ml/ray/storage/s3/minio/secret.md
@@ -1,0 +1,5 @@
+# Configure MinIO Kubernetes secret for Ray Workflows
+
+```shell
+export ML_RAY_STORAGE_S3_KUBERNETES_SECRET=ml.ray.s3.kubernetes.secret.minio
+```

--- a/guidebooks/s3/minio/kubernetes/install.md
+++ b/guidebooks/s3/minio/kubernetes/install.md
@@ -25,8 +25,20 @@ kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} wait --for=condition=Ready pod/minio 
 ```
 
 ```shell
+export S3_ENDPOINT_URL=http://minio-svc:9000
+```
+
+```shell
+export AWS_ACCESS_KEY_ID=minioadmin
+```
+
+```shell
+export AWS_SECRET_ACCESS_KEY=minioadmin
+```
+
+```shell
 ---
 validate: kubectl get ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} pod minio
 ---
-kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} exec minio-client -- mc alias set minio http://minio-svc:9000 minioadmin minioadmin
+kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} exec minio-client -- mc alias set minio $S3_ENDPOINT_URL $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 ```


### PR DESCRIPTION
Ugh, waste of time for now. I don't think there's a way to specify a non-default (i.e. non-aws) endpoint_url for ray workflow storage.