### PR TITLE
fix: ml/codeflare/training/byoc may not stop ray cluster automatically

### DIFF
--- a/guidebooks/ml/codeflare/training/byoc/index.md
+++ b/guidebooks/ml/codeflare/training/byoc/index.md
@@ -8,7 +8,7 @@ imports:
     - ml/ray/run/logs/init.md
     - ml/ray/start
     - ./submit
-    - ml/ray/stop
+    - ml/ray/stop/kubernetes/with-known-cluster-name
 ---
 
 # Bring Your Own Code

--- a/guidebooks/ml/codeflare/training/roberta/_roberta.md
+++ b/guidebooks/ml/codeflare/training/roberta/_roberta.md
@@ -4,7 +4,7 @@ imports:
     - ml/ray/v1/gpu
     - ml/ray/start
     - ./submit.md
-    - ml/ray/stop
+    - ml/ray/stop/kubernetes/with-known-cluster-name
 ---
 
 # Pre-Train a RoBERTa Language Model from Pre-tokenized Data

--- a/guidebooks/ml/ray/stop/index.md
+++ b/guidebooks/ml/ray/stop/index.md
@@ -2,4 +2,4 @@
 
 Only Kubernetes is supported, for now.
 
---8<-- "./kubernetes.md"
+--8<-- "./kubernetes"

--- a/guidebooks/ml/ray/stop/kubernetes/index.md
+++ b/guidebooks/ml/ray/stop/kubernetes/index.md
@@ -1,0 +1,7 @@
+---
+imports:
+    - ml/ray/cluster/choose
+    - ./with-known-cluster-name
+---
+
+# Stop Ray in your Kubernetes Cluster

--- a/guidebooks/ml/ray/stop/kubernetes/with-known-cluster-name.md
+++ b/guidebooks/ml/ray/stop/kubernetes/with-known-cluster-name.md
@@ -3,7 +3,6 @@ imports:
     - kubernetes/helm3
     - kubernetes/kubectl
     - kubernetes/choose/ns
-    - ml/ray/cluster/choose
 ---
 
 # Stop Ray in your Kubernetes Cluster


### PR DESCRIPTION
if some other ray cluster (other than the one started for this run) is also in existence, then on completion the user will be presented with a list of multiple clusters to stop. this PR fixes that issue (also in roberta) by introducing

guidebooks/ml/ray/stop/kubernetes/with-known-cluster-name