### PR TITLE
fix: ml/ray/run/pod-vmstat-memory does not support cgroup v2 api

### DIFF
--- a/guidebooks/ml/ray/run/pod-vmstat-memory.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat-memory.sh
@@ -11,5 +11,5 @@ if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
 
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -o name \
     | xargs ${REPLSIZE} -P128 -I {} -n1 \
-            sh -c "sleep 0.\$(shuf -i 100-2000 -n1); kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"while true; do echo \\\"\\\$(hostname) \\\$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes) \\\$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)\\\"; sleep 10; done\"" \
+            sh -c "sleep 0.\$(shuf -i 100-2000 -n1); kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"while true; do echo \\\"\\\$(hostname) \\\$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.current) \\\$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.max)\\\"; sleep 10; done\"" \
     >> "${STREAMCONSUMER_RESOURCES}pod-memory.txt"


### PR DESCRIPTION
with this PR, hopefully that guidebook now supports both v1 and v2 apis