### PR TITLE
fix: kubernetes image-pull can hang if cluster is not reachable

### DIFF
--- a/guidebooks/kubernetes/choose/secret/image-pull.md
+++ b/guidebooks/kubernetes/choose/secret/image-pull.md
@@ -7,7 +7,7 @@ imports:
 
 An [image pull secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) allows your Kubernetes [pods](https://kubernetes.io/docs/concepts/workloads/pods/) to pull images from a private container registry. If your image is public, you may use the "No secret needed" option.
 
-=== "expand(kubectl get ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} secret --field-selector type=kubernetes.io/dockerconfigjson -o=custom-columns=NAME:.metadata.name --no-headers, Image pull secrets)"
+=== "expand([ -z ${KUBE_NS_ARG} ] && exit 1 || kubectl get ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} secret --field-selector type=kubernetes.io/dockerconfigjson -o=custom-columns=NAME:.metadata.name --no-headers, Image pull secrets)"
     ```shell
     export IMAGE_PULL_SECRET=${choice}
     ```

--- a/guidebooks/ml/codeflare/training/byoc/index.md
+++ b/guidebooks/ml/codeflare/training/byoc/index.md
@@ -2,7 +2,7 @@
 imports:
     - util/jobid
     - ./form
-    - kubernetes/secrets/image-pull
+    - kubernetes/choose/secret/image-pull
     - s3/choose/bucket/maybe
     - ml/ray/storage/s3/maybe
     - ml/ray/run/logs/init.md


### PR DESCRIPTION
BREAKING CHANGE: rename kubernetes/secrets/image-pull to kubernetes/choose/secret/image-pull