### PR TITLE
fix: work around finally ordering issue

### DIFF
--- a/guidebooks/ml/codeflare/training/byoc/index.md
+++ b/guidebooks/ml/codeflare/training/byoc/index.md
@@ -6,7 +6,10 @@ imports:
     - s3/choose/bucket/maybe
     - ml/ray/storage/s3/maybe
     - ml/ray/run/logs/init.md
+    - ml/ray/start
     - ./submit
+finally:
+    - ml/ray/stop/kubernetes/with-known-cluster-name
 ---
 
 # Bring Your Own Code

--- a/guidebooks/ml/codeflare/training/byoc/submit.md
+++ b/guidebooks/ml/codeflare/training/byoc/submit.md
@@ -1,10 +1,3 @@
----
-imports:
-    - ml/ray/start
-finally:
-    - ml/ray/stop/kubernetes/with-known-cluster-name
----
-
 # Run it
 
 Submit a bring-your-own job.

--- a/guidebooks/ml/codeflare/training/demos/getting-started/index.md
+++ b/guidebooks/ml/codeflare/training/demos/getting-started/index.md
@@ -1,6 +1,9 @@
 ---
 imports:
     - util/jobid
+    - ml/ray/start
     - ./submit
+finally:
+    - ml/ray/stop/kubernetes/with-known-cluster-name
 ---
 

--- a/guidebooks/ml/codeflare/training/demos/getting-started/submit.md
+++ b/guidebooks/ml/codeflare/training/demos/getting-started/submit.md
@@ -1,10 +1,3 @@
----
-imports:
-    - ml/ray/start
-finally:
-    - ml/ray/stop/kubernetes/with-known-cluster-name
----
-
 # Simple Training Demo
 
 This quickstart will show how to quickly get started with submitting distributed training jobs in CodeFlare.

--- a/guidebooks/ml/codeflare/training/roberta/_roberta.md
+++ b/guidebooks/ml/codeflare/training/roberta/_roberta.md
@@ -2,7 +2,10 @@
 imports:
     - util/jobid
     - ml/ray/v1/gpu
+    - ml/ray/start
     - ./submit.md
+finally:
+    - ml/ray/stop/kubernetes/with-known-cluster-name
 ---
 
 # Pre-Train a RoBERTa Language Model from Pre-tokenized Data

--- a/guidebooks/ml/codeflare/training/roberta/submit.md
+++ b/guidebooks/ml/codeflare/training/roberta/submit.md
@@ -1,10 +1,3 @@
----
-imports:
-    - ml/ray/start
-finally:
-    - ml/ray/stop/kubernetes/with-known-cluster-name
----
-
 # Pre-Train a RoBERTa Language Model from Pre-tokenized Data
 
 The


### PR DESCRIPTION
ugh, for now finally blocks are not executed after code blocks within the given file. i think this is a general problem with imports; they are always executed before any code blocks in that same file, even for `:import{}` inline imports (rather than topmatter imports).