### PR TITLE
fix: s3fs secret and claim name should hash in cluster name

### DIFF
--- a/guidebooks/s3/choose/s3fs/kubernetes/init.md
+++ b/guidebooks/s3/choose/s3fs/kubernetes/init.md
@@ -3,9 +3,9 @@ export S3_DATA=premounted
 ```
 
 ```shell
-export S3_S3FS_CLAIM="s3fs.claim.${S3_BUCKET}"
+export S3_S3FS_CLAIM="s3fs.claim.${RAY_KUBE_CLUSTER_NAME}.${S3_BUCKET}"
 ```
 
 ```shell
-export S3_S3FS_SECRET="s3fs.secret.${S3_BUCKET}"
+export S3_S3FS_SECRET="s3fs.secret.${RAY_KUBE_CLUSTER_NAME}.${S3_BUCKET}"
 ```


### PR DESCRIPTION
Otherwise, two jobs in the same namespace, but that need access to different s3 data, will collide.