### PR TITLE
feat: improve console readability of ml/ray/run/pod-vmstat and memory stats

### DIFF
--- a/guidebooks/ml/ray/run/pod-vmstat-memory.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat-memory.sh
@@ -5,11 +5,12 @@ if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
 fi
 
 # staggered starts
-sleep 0.$(shuf -i 10000-11000 -n1)
+# sleep 0.$(shuf -i 10000-11000 -n1)
 
 if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
 
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -o name \
     | xargs ${REPLSIZE} -P128 -I {} -n1 \
-            sh -c "sleep 0.\$(shuf -i 100-2000 -n1); kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"while true; do echo \\\"\\\$(hostname) \\\$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.current) \\\$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.max)\\\"; sleep 10; done\"" \
-    >> "${STREAMCONSUMER_RESOURCES}pod-memory.txt"
+            sh -c "kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"while true; do echo \\\"\\\$(hostname) \\\$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.current) \\\$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.max)\\\" | awk '{printf(\\\"%s %s %s %5.2f%% [Mem Utilization]\\\n\\\", \\\$1, \\\$2, \\\$3, 100*\\\$2/\\\$3)}'; sleep 10; done\"" \
+    | sed -lE 's/^ray-.+-(ray-.+)$/\x1B[34m\1\x1B[0m/' \
+    | tee -a "${STREAMCONSUMER_RESOURCES}pod-memory.txt"

--- a/guidebooks/ml/ray/run/pod-vmstat.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat.sh
@@ -5,11 +5,12 @@ if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
 fi
 
 # staggered starts
-sleep 0.$(shuf -i 5000-7000 -n1)
+# sleep 0.$(shuf -i 5000-7000 -n1)
 
 if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
 
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -o name \
     | xargs ${REPLSIZE} -P128 -I {} -n1 \
-            sh -c "sleep 0.\$(shuf -i 100-2000 -n1); kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"vmstat 2 --timestamp | awk -Winteractive -v pod=\\\$(hostname) 'FNR==1 {x=substr(pod,length(\\\"Hostname\\\") + 1); gsub(/./, \\\"-\\\", x); print \\\"Hostname \\\" x,\\\$0} FNR>1 {print pod,\\\$0}'\"" \
-    >> "${STREAMCONSUMER_RESOURCES}pod-vmstat.txt"
+            sh -c "kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"vmstat 5 --timestamp | awk -Winteractive -v pod=\\\$(hostname) 'FNR>2 {printf(\\\"%s %2s %2s %2s %2s %2s        %5.2f%% [CPU Utilization]\\\n\\\", pod, \\\$13, \\\$14, \\\$15, \\\$16, \\\$17, \\\$13+\\\$14)}'\"" \
+    | sed -lE 's/^ray-.+-(ray-.+)$/\x1B[33m\1\x1B[0m/' \
+    | tee -a "${STREAMCONSUMER_RESOURCES}pod-vmstat.txt"


### PR DESCRIPTION
BREAKING CHANGE: this breaks any clients that were assuming a normal vmstat format for the cpu stats. it is now limited to the cpu columns (i.e. us sy id wa st).