### PR TITLE
feat: remove ray autoscaler option in ml/ray/cluster/kubernetes/choose-pod-scheduler

### DIFF
--- a/guidebooks/ml/ray/cluster/kubernetes/choose-pod-scheduler.md
+++ b/guidebooks/ml/ray/cluster/kubernetes/choose-pod-scheduler.md
@@ -18,19 +18,6 @@ To schedule your job's work, you have several scheduler options.
     export KUBE_POD_MANAGER_NON_ROOT=true
     ```
 
-=== "Use the Ray Autoscaler"
-
-    If you run one application at a time, whose demand varies greatly as
-    it runs (e.g. from one phase to the next), use the [Ray
-    Autoscaler](https://www.anyscale.com/blog/autoscaling-clusters-with-ray)
-    to manage the workload. *Requires root privileges to your cluster.*
-
-    ```shell
-    export KUBE_POD_MANAGER=ray
-    ```
-
-    :import{ml/ray/hacks/openshift/uid-range}
-
 === "Use the Multi-user Enhanced Kubernetes Scheduler"
 
     :import{kubernetes/mcad/choose/scheduler}


### PR DESCRIPTION
BREAKING CHANGE: this removes support for using the ray operator. There is some breaking skew in ray 2 that we have not accounted for in our fork of the ray helm chart.