### PR TITLE
feat: allow use of vmstat and gpu utilization tracking outside of ray

### DIFF
--- a/guidebooks/ml/ray/run/gpu-utilization.md
+++ b/guidebooks/ml/ray/run/gpu-utilization.md
@@ -1,5 +1,6 @@
 ---
 imports:
+    - kubernetes/choose/ns
     - ml/ray/start/kubernetes/label-selectors.md
 ---
 

--- a/guidebooks/ml/ray/run/gpu-utilization.sh
+++ b/guidebooks/ml/ray/run/gpu-utilization.sh
@@ -7,6 +7,8 @@ fi
 
 if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
 
+if [ -z "$STREAMCONSUMER_RESOURCES" ]; then STREAMCONSUMER_RESOURCES="/tmp/"; fi
+
 if [ -z "$QUIET_CONSOLE" ]; then
     kubectl get pod -l ${KUBE_POD_LABEL_SELECTOR} ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -o name \
         | xargs ${REPLSIZE} -P128 -I {} -n1 \

--- a/guidebooks/ml/ray/run/pod-stats.md
+++ b/guidebooks/ml/ray/run/pod-stats.md
@@ -1,5 +1,6 @@
 ---
 imports:
+    - kubernetes/choose/ns
     - ml/ray/start/kubernetes/label-selectors.md
 ---
 
@@ -27,4 +28,8 @@ mycluster-ray-worker-type-np2vr   1        1        32Gi
 
 ```shell.async
 --8<-- "./pod-stats.sh"
+```
+
+```shell
+if [ -n "$WAIT" ]; then sleep 100000000; fi
 ```

--- a/guidebooks/ml/ray/run/pod-stats.sh
+++ b/guidebooks/ml/ray/run/pod-stats.sh
@@ -4,6 +4,8 @@ if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
     exit
 fi
 
+if [ -z "$STREAMCONSUMER_RESOURCES" ]; then STREAMCONSUMER_RESOURCES="/tmp/"; fi
+
 while true; do
     sleep 10
 

--- a/guidebooks/ml/ray/run/pod-vmstat-memory.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat-memory.sh
@@ -9,6 +9,8 @@ fi
 
 if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
 
+if [ -z "$STREAMCONSUMER_RESOURCES" ]; then STREAMCONSUMER_RESOURCES="/tmp/"; fi
+
 # Use the user's timezone, to help with readability
 TZ=$(date +%Z)
 

--- a/guidebooks/ml/ray/run/pod-vmstat.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat.sh
@@ -9,6 +9,8 @@ fi
 
 if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
 
+if [ -z "$STREAMCONSUMER_RESOURCES" ]; then STREAMCONSUMER_RESOURCES="/tmp/"; fi
+
 # Use the user's timezone, to help with readability
 TZ=$(date +%Z)
 

--- a/guidebooks/ml/ray/start/kubernetes/label-selectors.md
+++ b/guidebooks/ml/ray/start/kubernetes/label-selectors.md
@@ -1,15 +1,17 @@
 # Helpful Kubernetes Label Selectors for Ray
 
+A Kubernetes label selector that can be used to query for the head node.
+```shell
+export KUBE_POD_RAY_HEAD_LABEL_SELECTOR=${KUBE_POD_LABEL_SELECTOR-ray-user-node-type=rayHeadType,app.kubernetes.io/name=${RAY_KUBE_CLUSTER_NAME}}
+```
+
+A Kubernetes label selector that can be used to query for both workers and the head node.
+```shell
+export KUBE_PODFULL_LABEL_SELECTOR=${KUBE_POD_LABEL_SELECTOR-app.kubernetes.io/name=${RAY_KUBE_CLUSTER_NAME},ray-node-type}
+```
+
 A Kubernetes label selector that can be used to query for workers.
 ```shell
-export KUBE_POD_LABEL_SELECTOR=ray-user-node-type=rayWorkerType,app.kubernetes.io/name=${RAY_KUBE_CLUSTER_NAME}
+export KUBE_POD_LABEL_SELECTOR=${KUBE_POD_LABEL_SELECTOR-ray-user-node-type=rayWorkerType,app.kubernetes.io/name=${RAY_KUBE_CLUSTER_NAME}}
 ```
 
-```shell
-export KUBE_POD_RAY_HEAD_LABEL_SELECTOR=ray-user-node-type=rayHeadType,app.kubernetes.io/name=${RAY_KUBE_CLUSTER_NAME}
-```
-
-A Kubernetes label selector that can be used to query for workers and the head node.
-```shell
-export KUBE_PODFULL_LABEL_SELECTOR=app.kubernetes.io/name=${RAY_KUBE_CLUSTER_NAME},ray-node-type
-```


### PR DESCRIPTION
One only needs to specify the label selector that identifies the pods to be tracked.

e.g.

```shell
WAIT=true KUBE_POD_LABEL_SELECTOR='ray-cluster-name=nickm-c887b3d7-73f3-46ea-a427-7242e6ed459c' codeflare ml/ray/run/pod-stats
```