### PR TITLE
fix: gpu-utilization.md may fail on zsh if profile specifies no gpus

### DIFF
--- a/guidebooks/ml/ray/run/gpu-utilization.md
+++ b/guidebooks/ml/ray/run/gpu-utilization.md
@@ -12,7 +12,7 @@ display the utilization metric in red text (`[31m`), and to turn "Gpu"
 into "Gpu Utilization".
 
 ```shell.async
-if [ ${NUM_GPUS-0} -gt 0 ]; then
+if [[ ${NUM_GPUS-0} -gt 0 ]]; then
   --8<-- "./gpu-utilization.sh"
 fi
 ```


### PR DESCRIPTION
If `NUM_GPUS=""` i.e. an empty string, then our if check fails in zsh