### PR TITLE
fix: kube events lines are way too wide

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/events.md
+++ b/guidebooks/ml/ray/start/kubernetes/events.md
@@ -6,7 +6,7 @@ not associated with our job. We pipe to grep here to work around that.
 > Without `--line-buffered`, output is batched up by the `tee`? :(
 
 ```shell.async
-kubectl get events ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -o wide --watch-only | grep --line-buffered ${JOB_ID} | tee "${STREAMCONSUMER_EVENTS-/tmp/}kubernetes.txt"
+kubectl get events ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} --watch-only | grep --line-buffered ${JOB_ID} | awk -Winteractive '{gsub(/^[0-9]+s[ ]+/, ""); print "\x1b[1;2;36m[Cluster Event] \x1b[0;2;36m" $0 "\x1b[0m"; fflush()}' | sed -lE 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//g' | tee "${STREAMCONSUMER_EVENTS-/tmp/}kubernetes.txt"
 ```
 
 ```shell.async


### PR DESCRIPTION
1) trim off job uuid
2) trim off age
3) add [Cluster Event] line prefix
4) don't use -o wide
5) use a dim/cyan color