### PR TITLE
fix: avoid use of env vars for workdir tarball

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/workdir.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/workdir.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "ray.workdir" . }}
-data:
-  RAY_WORKDIR_ENCODED: {{ .Values.workdir }}
+immutable: true
+binaryData:
+  workdir.tar.bz2: {{ .Values.workdir | b64enc }}
 {{ end }}

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
@@ -98,16 +98,15 @@ if [ -n "$CUSTOM_WORKING_DIR" ]; then
             cp "$CUSTOM_WORKING_DIR"/.rayignore $excludeFile
         fi
 
-        workdirEnc=$(mktemp)
-        tar -jcf - --no-xattrs \
+        workdirTarball=$(mktemp)
+        tar -jcf $workdirTarball --no-xattrs \
             --exclude '*~' --exclude '*.out' --exclude '*.log' --exclude '*.err' --exclude '.rayignore' \
             --exclude-vcs \
             --exclude-from $excludeFile \
-            -C "$CUSTOM_WORKING_DIR" . \
-            | base64 | tr -d '\n' > $workdirEnc # see above for discussion of tr
+            -C "$CUSTOM_WORKING_DIR" .
 
-        workdir="--set-file workdir=${workdirEnc}"
-        echo "$(tput setaf 4)[Helm] Using workdir via configmap=$(tput setaf 5)$(cat $workdirEnc | wc -c | awk '{print $1}') bytes$(tput sgr0)"
+        workdir="--set-file workdir=${workdirTarball}"
+        echo "$(tput setaf 4)[Helm] Using workdir via configmap=$(tput setaf 5)$(cat $workdirTarball | wc -c | awk '{print $1}') bytes$(tput sgr0)"
     elif [ ! -e "$CUSTOM_WORKING_DIR" ]; then
         echo "$(tput setaf 1)[Helm] Error: custom working directory specified, but path to directory not found $CUSTOM_WORKING_DIR$(tput sgr0)"
         exit 1


### PR DESCRIPTION
With this change, we instead use a volume and volumeMount to transmit the workdir to the pod. Unfortunately, this still requires base64-encoding the workdir in the configmap, as it is not possible to store binary data in a configmap.