### PR TITLE
feat: move cpu and memory utilization to be first column

### DIFF
--- a/guidebooks/ml/ray/run/pod-vmstat-memory.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat-memory.sh
@@ -7,7 +7,10 @@ fi
 # staggered starts
 # sleep 0.$(shuf -i 10000-11000 -n1)
 
-if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
+if [ $(uname) = "Darwin" ]; then
+    export REPLSIZE="-S5000"
+    export AWKOPTS="-Winteractive"
+fi
 
 if [ -z "$STREAMCONSUMER_RESOURCES" ]; then STREAMCONSUMER_RESOURCES="/tmp/"; fi
 
@@ -17,7 +20,6 @@ TZ=$(date +%Z)
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -o name \
         --field-selector=status.phase==Running \
     | xargs ${REPLSIZE} -P128 -I {} -n1 \
-            sh -c "kubectl exec --pod-running-timeout=1h ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"while true; do echo \\\"\\\$(hostname) \\\$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.current) \\\$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.max)\\\" | awk -Winteractive -v now=\\\"\\\$(TZ=$TZ date +'%Y-%m-%d %H:%M:%S %Z')\\\" '{printf(\\\"\\\x1b[34m%s %13s %13s   [Mem Utilization %5.1f%%] %s\\\x1b[0m\\\n\\\", \\\$1, \\\$2, \\\$3, 100*\\\$2/\\\$3, now)}'; sleep 5; done\"" \
-    | sed -uE 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//g' \
+            sh -c "kubectl exec --pod-running-timeout=1h ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"while true; do echo \\\"\\\$(hostname | sed -E 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//') \\\$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.current) \\\$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.max)\\\" | awk $AWKOPTS -v now=\\\"\\\$(TZ=$TZ date +'%Y-%m-%d %H:%M:%S %Z')\\\" '{printf(\\\"\\\x1b[1;34m[Mem Utilization %5.1f%%] \\\x1b[0;34m%-30s \\\x1b[2m%13s %13s %s\\\x1b[0m\\\n\\\", 100*\\\$2/\\\$3, \\\$1, \\\$2, \\\$3, now)}'; sleep 5; done\"" \
     | tee -a "${STREAMCONSUMER_RESOURCES}pod-memory.txt" \
     1>&2

--- a/guidebooks/ml/ray/run/pod-vmstat.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat.sh
@@ -7,7 +7,10 @@ fi
 # staggered starts
 # sleep 0.$(shuf -i 5000-7000 -n1)
 
-if [ $(uname) = "Darwin" ]; then export REPLSIZE="-S5000"; fi
+if [ $(uname) = "Darwin" ]; then
+    export REPLSIZE="-S5000"
+    export AWKOPTS="-Winteractive"
+fi
 
 if [ -z "$STREAMCONSUMER_RESOURCES" ]; then STREAMCONSUMER_RESOURCES="/tmp/"; fi
 
@@ -17,7 +20,6 @@ TZ=$(date +%Z)
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -o name \
         --field-selector=status.phase==Running \
     | xargs ${REPLSIZE} -P128 -I {} -n1 \
-            sh -c "kubectl exec --pod-running-timeout=1h ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"TZ=$TZ vmstat --timestamp 5 | awk -Winteractive -v timezone=$TZ -v pod=\\\$(hostname) '\\\$NF !~ /timestamp/ && \\\$3 != \\\"swpd\\\" {printf(\\\"\\\x1b[33m%s %14s %2s %2s %2s %2s %2s [CPU Utilization %5.1f%%] %s %s %s\\\x1b[0m\\\n\\\", pod, \\\$4, \\\$13, \\\$14, \\\$15, \\\$16, \\\$17, \\\$13+\\\$14, \\\$(NF-1), \\\$NF, timezone)}'\"" \
-    | sed -uE 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//g' \
+            sh -c "kubectl exec --pod-running-timeout=1h ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"TZ=$TZ vmstat --timestamp 5 | awk $AWKOPTS -v timezone=$TZ -v pod=\\\$(hostname | sed -E 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//') '\\\$NF !~ /timestamp/ && \\\$3 != \\\"swpd\\\" {printf(\\\"\\\x1b[1;33m[CPU Utilization %5.1f%%] \\\x1b[0;33m%-30s \\\x1b[2m%14s %2s %2s %2s %2s %2s %s %s %s\\\x1b[0m\\\n\\\", \\\$13+\\\$14, pod, \\\$4, \\\$13, \\\$14, \\\$15, \\\$16, \\\$17, \\\$(NF-1), \\\$NF, timezone)}'\"" \
     | tee -a "${STREAMCONSUMER_RESOURCES}pod-vmstat.txt" \
     1>&2


### PR DESCRIPTION
This also should fix the warning that Winteractive is not a known option on linux/gnu awk.