### PR TITLE
fix: specify parallelism for ray worker Job

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Values.clusterNamespace }}
 spec:
   ttlSecondsAfterFinished: 100
+  parallelism: {{ .Values.podTypes.rayWorkerType.maxWorkers | default 1 }}
   completions: {{ .Values.podTypes.rayWorkerType.maxWorkers | default 1 }}
   template:
     metadata:


### PR DESCRIPTION
Without this, the Job controller schedules one pod at a time. If the coscheduler is used (gang scheduling via PodGroup), then... there is a lockup.