### PR TITLE
fix: major cleanups to job log streaming

### DIFF
--- a/guidebooks/ml/codeflare/training/demos/getting-started/submit.md
+++ b/guidebooks/ml/codeflare/training/demos/getting-started/submit.md
@@ -2,6 +2,7 @@
 imports:
     - util/jobid
     - ./setup
+    - ml/ray/run/logs/init
     - ml/ray/start
 finally:
     - ./cleanup

--- a/guidebooks/ml/ray/aggregator/setup.md
+++ b/guidebooks/ml/ray/aggregator/setup.md
@@ -1,8 +1,3 @@
----
-imports:
-    - util/jq
----
-
 # Log Aggregator Setup
 
 Set up some variables that are dependently on the selected run.
@@ -15,5 +10,5 @@ fi
 ```
 
 ```shell
-export NUM_GPUS=${NUM_GPUS-$(echo "$JOB_ENV" | jq -cr '.runtime_env.env_vars.NUM_GPUS')}
+export NUM_GPUS=${NUM_GPUS-0}
 ```

--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -12,9 +12,13 @@ We will stream out a suite of data, including resource utilization metrics and j
 --8<-- "./pod-stats.md"
 --8<-- "./gpu-utilization.md"
 
-## Capture Job Definition
+## Stream Ray Runtime Env Setup
 
---8<-- "./job-definition.md"
+--8<-- "./runtime-env-setup.md"
+
+## Stream Ray Job Status
+
+--8<-- "./status-poller.md"
 
 ## Stream Ray Job Logs
 
@@ -24,7 +28,7 @@ Wait for the job to be active.
 if [ -n "$LOG_AGGREGATOR_POD_NAME" ] && [ -n "$LOG_AGGREGATOR_LOGDIR" ]; then
     echo "Client-side aggregator Ray job log collection about to commence"
 else
-    while true; do if [ "$(curl -s -I $RAY_ADDRESS/api/jobs/$JOB_ID | head -n 1 | cut -d$' ' -f2)" = "200" ]; then break; sleep 1; fi; done
+    while true; do if [[ $(curl -s -I $RAY_ADDRESS/api/jobs/$JOB_ID 2> /dev/null | head -n 1 | cut -d$' ' -f2) = 200 ]]; then break; sleep 1; fi; done
 fi
 ```
 

--- a/guidebooks/ml/ray/run/logs/via-websocat.md
+++ b/guidebooks/ml/ray/run/logs/via-websocat.md
@@ -51,8 +51,8 @@ if [ -n "${STREAMCONSUMER_LOGS}" ]; then
                     done
                 fi
             fi
-            jobstatus="$(curl -s ${RAY_ADDRESS}/api/jobs/${JOB_ID} | jq -r .status)"
-            echo "Job status for ${JOB_ID}: ${jobstatus-Unknown, cannot contact Ray}"
+            jobstatus="$(curl -s ${RAY_ADDRESS}/api/jobs/${JOB_ID} | jq -r .status | awk '{s=$1; print toupper(substr(s, 1, 1)) tolower(substr( s, 2 ))}')"
+            echo -e "\x1b[1;2;32m[Job \x1b[0;32m${jobstatus-Unknown}\x1b[1;2;32m]\x1b[0;2;32m * Run has completed $(tput sgr0)$(tput dim)$(tput setaf 2)$(date -u +'%Y-%m-%dT%H:%M:%SZ')$(tput sgr0)\x1b[0m" | tee -a "${STREAMCONSUMER_LOGS}job.txt"
         fi
     fi
 fi

--- a/guidebooks/ml/ray/run/pod-vmstat.sh
+++ b/guidebooks/ml/ray/run/pod-vmstat.sh
@@ -13,12 +13,8 @@ fi
 
 if [ -z "$STREAMCONSUMER_RESOURCES" ]; then STREAMCONSUMER_RESOURCES="/tmp/"; fi
 
-# Use the user's timezone, to help with readability
-TZ=$(date +%Z)
-
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -o name \
         --field-selector=status.phase==Running \
     | xargs ${REPLSIZE} -P128 -I {} -n1 \
-            sh -c "kubectl exec --pod-running-timeout=1h ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"TZ=$TZ vmstat --timestamp 5 | awk -Winteractive -v timezone=$TZ -v pod=\\\$(hostname | sed -E 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//') '\\\$NF !~ /timestamp/ && \\\$3 != \\\"swpd\\\" {printf(\\\"\\\x1b[1;33m[CPU Utilization %5.1f%%] \\\x1b[0;33m%-30s \\\x1b[2m%14s %2s %2s %2s %2s %2s %s %s %s\\\x1b[0m\\\n\\\", \\\$13+\\\$14, pod, \\\$4, \\\$13, \\\$14, \\\$15, \\\$16, \\\$17, \\\$(NF-1), \\\$NF, timezone)}'\"" \
-    | tee -a "${STREAMCONSUMER_RESOURCES}pod-vmstat.txt" \
-    1>&2
+            sh -c "kubectl exec --pod-running-timeout=1h ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} {} -- sh -c \"vmstat --timestamp 5 | awk -Winteractive -v pod=\\\$(hostname) '\\\$NF !~ /timestamp/ && \\\$3 != \\\"swpd\\\" {printf(\\\"\\\x1b[1;33m[CPU Utilization %4.1f%%] \\\x1b[0;33m%-30s \\\x1b[2m%14s %2s %2s %2s %2s %2s %sT%sZ\\\x1b[0m\\\n\\\", \\\$13+\\\$14, pod, \\\$4, \\\$13, \\\$14, \\\$15, \\\$16, \\\$17, \\\$(NF-1), \\\$NF)}'\"" \
+    >> "${STREAMCONSUMER_RESOURCES}pod-vmstat.txt"

--- a/guidebooks/ml/ray/run/runtime-env-agent.sh
+++ b/guidebooks/ml/ray/run/runtime-env-agent.sh
@@ -1,0 +1,8 @@
+if [ -z "$STREAMCONSUMER_EVENTS" ]; then STREAMCONSUMER_EVENTS="/tmp/"; fi
+
+kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${RAY_HEAD_POD} -- \
+        sh -c "tail -F /tmp/ray/session_latest/logs/runtime_env_agent.log 2> /dev/null | grep -v 'raylet\|Unused\|deleted'" \
+    | sed -uE 's/[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}//' \
+    | while read line ; do echo -e "$line \x1b[0;36m$(date -u +'%Y-%m-%dT%H:%M:%SZ')" ; done \
+    | sed -uE "s/^(.+)$/\x1b[1;2;36m[Pips \x1b[0;36mInstalling\x1b[1;2;36m]\x1b[0;2;36m pod\/${RAY_HEAD_POD} \1\x1b[0m/" \
+    | tee -a "${STREAMCONSUMER_EVENTS}runtime-env-setup.txt"

--- a/guidebooks/ml/ray/run/runtime-env-setup.md
+++ b/guidebooks/ml/ray/run/runtime-env-setup.md
@@ -1,0 +1,13 @@
+---
+imports:
+    - kubernetes/choose/ns
+    - ml/ray/cluster/head
+---
+
+```shell.async
+--8<-- "./runtime-env-agent.sh"
+```
+
+```shell.async
+--8<-- "./runtime-env-setup.sh"
+```

--- a/guidebooks/ml/ray/run/runtime-env-setup.sh
+++ b/guidebooks/ml/ray/run/runtime-env-setup.sh
@@ -1,0 +1,8 @@
+if [ -z "$STREAMCONSUMER_EVENTS" ]; then STREAMCONSUMER_EVENTS="/tmp/"; fi
+
+kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${RAY_HEAD_POD} -- \
+        sh -c "tail -F /tmp/ray/session_latest/logs/runtime_env_setup-01000000.log 2> /dev/null " \
+    | sed -uE 's/[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}//' \
+    | while read line ; do echo -e "$line \x1b[0;36m$(date -u +'%Y-%m-%dT%H:%M:%SZ')" ; done \
+    | sed -uE "s/^(.+)$/\x1b[1;2;36m[Pips \x1b[0;36mInstalling\x1b[1;2;36m]\x1b[0;2;36m pod\/${RAY_HEAD_POD} \1\x1b[0m/" \
+    | tee -a "${STREAMCONSUMER_EVENTS}runtime-env-setup.txt"

--- a/guidebooks/ml/ray/run/status-poller.md
+++ b/guidebooks/ml/ray/run/status-poller.md
@@ -1,0 +1,9 @@
+---
+imports:
+    - kubernetes/choose/ns
+    - ml/ray/cluster/head
+---
+
+```shell.async
+--8<-- "./status-poller.sh"
+```

--- a/guidebooks/ml/ray/run/status-poller.sh
+++ b/guidebooks/ml/ray/run/status-poller.sh
@@ -1,0 +1,6 @@
+if [ -z "$STREAMCONSUMER_EVENTS" ]; then STREAMCONSUMER_EVENTS="/tmp/"; fi
+
+kubectl exec ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${RAY_HEAD_POD} -- \
+        bash -c 'while true; do statusResp="$(ray job status $JOB_ID 2> /dev/null)"; if [[ $? != 0 ]]; then status="Pending"; msg="Waiting for Ray to start up"; else status=$(echo "$statusResp" | grep "Status for job" | awk "{s=\$NF; print toupper(substr(s, 1, 1)) tolower(substr( s, 2 ))}"); msg="$(echo "$statusResp" | grep "Status message" | sed -uE "s/^.+ -- Status message: (.+)\$/\1/")"; echo "$(tput bold)$(tput dim)$(tput setaf 2)[Job $(tput sgr0)$(tput setaf 2)${status}$(tput bold)$(tput dim)$(tput setaf 2)] $(tput sgr0)$(tput dim)$(tput setaf 2)* ${msg}$(tput sgr0)"; fi; sleep 5; done;' \
+    | while read line ; do echo -e "$line $(tput sgr0)$(tput dim)$(tput setaf 2)$(date -u +'%Y-%m-%dT%H:%M:%SZ')$(tput sgr0)" ; done \
+    | tee -a "${STREAMCONSUMER_EVENTS}job-status.txt"

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -97,7 +97,7 @@ spec:
 
           args:
           {{ if .Values.workdir }}
-            - {{ print "set -e; set -o pipefail; " (include "ray.head.args" .) "; mkdir /tmp/workdir; tar -C /tmp/workdir -zxf /tmp/configmap/workdir/workdir.tar.gz; if [ ! -f /tmp/workdir/runtime-env.yaml ]; then touch /tmp/workdir/runtime-env.yaml; if [ -f /tmp/workdir/requirements.txt ]; then echo 'Splicing in requirements.txt'; awk 'BEGIN { print \"pip:\" } NF > 0 { print \"  - \" $0 }' /tmp/workdir/requirements.txt >> /tmp/workdir/runtime-env.yaml; fi; fi ; if [ -s /tmp/workdir/runtime-env.yaml ]; then echo 'Using runtime-env.yaml'; RUNTIME_ENV=\"--runtime-env=/tmp/workdir/runtime-env.yaml\"; fi; ls -l /tmp/workdir ; set +e; ray job submit --job-id " (.Values.jobId) " --address http://localhost:8265 --working-dir=/tmp/workdir $RUNTIME_ENV -- " (.Values.commandLinePrefix | default "python3 main.py") " " (.Values.dashdash | default "" | b64dec) "; echo \"Job complete, shutting down ray in 30 seconds...\"; sleep 30; ray stop" }}
+            - {{ print "set -e; set -o pipefail; " (include "ray.head.args" .) "; mkdir /tmp/workdir; tar -C /tmp/workdir -zxf /tmp/configmap/workdir/workdir.tar.gz; if [ ! -f /tmp/workdir/runtime-env.yaml ]; then touch /tmp/workdir/runtime-env.yaml; if [ -f /tmp/workdir/requirements.txt ]; then echo 'Splicing in requirements.txt'; awk 'BEGIN { print \"pip:\" } NF > 0 { print \"  - \" $0 }' /tmp/workdir/requirements.txt >> /tmp/workdir/runtime-env.yaml; fi; fi ; if [ -s /tmp/workdir/runtime-env.yaml ]; then echo 'Using runtime-env.yaml'; RUNTIME_ENV=\"--runtime-env=/tmp/workdir/runtime-env.yaml\"; fi; ls -l /tmp/workdir ; set +e; echo -e \"$(tput bold)$(tput dim)$(tput setaf 2)[Job $(tput sgr0)$(tput setaf 2)Submitted$(tput bold)$(tput dim)$(tput setaf 2)] $(tput sgr0)$(tput dim)$(tput setaf 2)Submitting job to ray$(tput sgr0)\"; ray job submit --job-id " (.Values.jobId) " --address http://localhost:8265 --working-dir=/tmp/workdir $RUNTIME_ENV -- " (.Values.commandLinePrefix | default "python3 main.py") " " (.Values.dashdash | default "" | b64dec) "; if [[ $? = 0 ]]; then jobstatus=Success; else jobstatus=Failed; fi; echo \"$(tput bold)$(tput dim)$(tput setaf 2)[Job $(tput sgr0)$(tput setaf 2)${jobstatus-Unknown}$(tput bold)$(tput dim)$(tput setaf 2)] $(tput sgr0)$(tput dim)$(tput setaf 2)Job has completed$(tput sgr0)\"; echo 'Shutting down ray in 30 seconds...'; sleep 30; ray stop" }}
           {{ else }}
             - {{ print (include "ray.head.args" .) " --block" }}
           {{ end }}
@@ -110,8 +110,8 @@ spec:
 
           startupProbe:
             periodSeconds: {{ .Values.startupProbe.periodSeconds | default 2 }}
-            failureThreshold: {{ .Values.startupProbe.failureThreshold | default 50 }}
-            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds | default 2 }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold | default 100 }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds | default 4 }}
             httpGet:
               path: /
               port: 8265

--- a/guidebooks/ml/ray/start/kubernetes/events.md
+++ b/guidebooks/ml/ray/start/kubernetes/events.md
@@ -1,8 +1,17 @@
-# Stream out Events from the Ray Head Node
+---
+imports:
+    - ./label-selectors
+---
 
-Kubernetes doesn't give us a great way to filter out events that are
-not associated with our job. We pipe to grep here to work around that. 
+# Stream out Worker Lifecycle Events
+
+Collect information pertaining to the status and behavior of the
+workers in a Kubernetes cluster.
 
 ```shell.async
 --8<-- "./events.sh"
+```
+
+```shell.async
+--8<-- "./pods.sh"
 ```

--- a/guidebooks/ml/ray/start/kubernetes/events.sh
+++ b/guidebooks/ml/ray/start/kubernetes/events.sh
@@ -9,7 +9,18 @@ while true; do
     else WATCH="--watch-only"
     fi
 
-    kubectl get events --ignore-not-found ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} $WATCH | awk $INT -v id=$JOB_ID 'index($4, id)>0 {sub(/^[0-9]+s[ ]+/, ""); print "\x1b[1;2;36m[Cluster Event] \x1b[0;2m" $0 "\x1b[0m"; fflush()}' | sed -uE 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//g'
+    kubectl get events -o custom-columns=KIND:.involvedObject.kind,NAME:.involvedObject.name,TIMESTAMP:.metadata.creationTimestamp,TYPE:.type,REASON:.reason,MESSAGE:.message --ignore-not-found ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} $WATCH \
+        | awk $INT -v id=$JOB_ID '
+index($2, id) > 0 {
+  printf "\x1b[1;2;35m[Workers \x1b[0;35m%s\x1b[1;2;35m]\x1b[0;2;35m", $5;
+  printf " \x1b[0;2;35m%s/%s %s", tolower($1), $2, $4; // name and reason
+  for (i=6;i<=NF;i++) printf " %s", $i; // message
+  print " \x1b[0;35m" $3 "\x1b[0m"; // timestamp
+  fflush();
+}' \
+        | tee -a "${STREAMCONSUMER_EVENTS}kubernetes.txt" \
+        | sed -uE 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//g'
+
     ITER=$(($ITER + 1))
     sleep 2
 done

--- a/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
+++ b/guidebooks/ml/ray/start/kubernetes/install-via-helm.sh
@@ -1,3 +1,5 @@
+# Prepare and submit cluster to Kubernetes
+
 set -e
 set -o pipefail
 

--- a/guidebooks/ml/ray/start/kubernetes/pods.sh
+++ b/guidebooks/ml/ray/start/kubernetes/pods.sh
@@ -1,0 +1,28 @@
+if [[ $(uname) = Linux ]]
+then INT="-Winteractive"
+fi
+
+# Use the user's timezone, to help with readability
+export TZ=$(date +%Z)
+
+ITER=0
+while true; do
+    if [[ $ITER = 0 ]]
+    then WATCH="--watch"
+    else WATCH="--watch-only"
+    fi
+
+    kubectl get pods -l ${KUBE_PODFULL_LABEL_SELECTOR} \
+            --no-headers --ignore-not-found \
+            ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} $WATCH \
+        | while read line ; do echo -e "$line \x1b[0;35m$(date -u +'%Y-%m-%dT%H:%M:%SZ')" ; done \
+        | awk $INT '{
+printf "\x1b[1;2;35m[Workers \x1b[0;35m%s\x1b[1;2;35m]\x1b[0;2;35m pod/%s %s %s %s\x1b[0m\n", $3, $1, $2, $4, $6, $5;
+fflush();
+}' \
+        | tee -a "${STREAMCONSUMER_EVENTS}pods.txt" \
+        | sed -uE 's/-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//g'
+
+    ITER=$(($ITER + 1))
+    sleep 2
+done

--- a/guidebooks/ml/ray/start/kubernetes/wait-for-head.md
+++ b/guidebooks/ml/ray/start/kubernetes/wait-for-head.md
@@ -4,11 +4,14 @@ imports:
 ---
 
 ```shell
+ITER=0
 while true; do
-    kubectl get pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_RAY_HEAD_LABEL_SELECTOR} | grep Running > /dev/null && break || echo "Waiting for Ray Head node"
-    sleep 1
+    if kubectl get pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_RAY_HEAD_LABEL_SELECTOR} | grep -q ray; then break; fi
+
+    if [[ $(($ITER % 10)) = 0 ]]; then echo "⌛ Waiting for Ray Head"; sleep 1; fi
+    ITER=$(($ITER + 1))
 done
 
 kubectl wait pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_RAY_HEAD_LABEL_SELECTOR} --for=condition=Ready --timeout=-1s && \
-    echo "Head node is ready"
+    echo "🚀 Ray Head is ready"
 ```

--- a/guidebooks/ml/ray/start/kubernetes/wait-for-workers.md
+++ b/guidebooks/ml/ray/start/kubernetes/wait-for-workers.md
@@ -2,12 +2,15 @@
 
 ```shell
 if [ "$MAX_WORKERS" -gt "0" ]; then
+    ITER=0
     while true; do
-        kubectl ${KUBE_CONTEXT_ARG} get pod ${KUBE_NS_ARG} -l ${KUBE_POD_LABEL_SELECTOR} | grep Running > /dev/null && break || echo "Waiting for Ray Worker nodes"
-        sleep 1
+      if kubectl get pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_LABEL_SELECTOR} | grep -q ray; then break; fi
+
+      if [[ $(($ITER % 10)) = 0 ]]; then echo "⌛ Waiting for Ray Workers"; sleep 1; fi
+      ITER=$(($ITER + 1))
     done
 
     kubectl wait pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${KUBE_POD_LABEL_SELECTOR} --for=condition=Ready --timeout=-1s && \
-        echo "Worker node is ready"
+        echo "🚀 Ray Workers are ready"
 fi
 ```

--- a/guidebooks/ml/torchx/run/wait-till-running.md
+++ b/guidebooks/ml/torchx/run/wait-till-running.md
@@ -8,9 +8,12 @@ imports:
 # Wait till Torchx Pods are Running
 
 ```shell
+ITER=0
 while true; do
-    kubectl get pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${TORCHX_INSTANCE_LABEL} | grep Running > /dev/null && break || echo "Waiting for Torchx workers to be deployed"
-    sleep 2
+    if kubectl get pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} -l ${TORCHX_INSTANCE_LABEL} 2>/dev/null | grep -q torchx; then break; fi
+
+    if [[ $(($ITER % 10)) = 0 ]]; then echo "⌛ Waiting for PyTorch Workers"; sleep 1; fi
+    ITER=$(($ITER + 1))
 done
 
 echo "Waiting for Torchx workers to be running"


### PR DESCRIPTION
- tracking of ray pip installs
- tracking of pod status
- more consistent prefixing of these streams
- wait for head/worker output cleanup (less noisy "Waiting for Ray Head....")
- removes ray job env capture, as it was not working and resulted in errors in the output
- cpu/mem/gpu streams now are not tee'd to stdout, only captured to the files