### PR TITLE
fix: bump openshift/oc to 4.12.9

### DIFF
--- a/guidebooks/openshift/oc.md
+++ b/guidebooks/openshift/oc.md
@@ -11,7 +11,7 @@ The `oc` CLI gives you command line access to your
 cluster.
 
 ```shell
-export OPENSHIFT_CLI_VERSION=4.10.33
+export OPENSHIFT_CLI_VERSION=4.12.9
 ```
 
 === "MacOS"


### PR DESCRIPTION
From 4.10.33. This fixes "Killed 9" on apple silicon. ref: https://bugzilla.redhat.com/show_bug.cgi?id=2059125