### PR TITLE
fix: assign gpus to ray head, if we are assigning them to workers

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -149,8 +149,8 @@ spec:
               cpu: {{ .Values.podTypes.rayHeadType.CPU }}
               memory: {{ .Values.podTypes.rayHeadType.memory }}
               ephemeral-storage: {{ .Values.podTypes.rayHeadType.storage }}
-              {{- if .Values.podTypes.rayHeadType.GPU }}
-              nvidia.com/gpu: {{ .Values.podTypes.rayHeadType.GPU }}
+              {{- if .Values.podTypes.rayWorkerType.GPU }}
+              nvidia.com/gpu: {{ .Values.podTypes.rayWorkerType.GPU }}
               {{- end }}
             limits:
               cpu: {{ .Values.podTypes.rayHeadType.CPU }}
@@ -163,7 +163,7 @@ spec:
               # cause problems for other pods.
               memory: {{ .Values.podTypes.rayHeadType.memory }}
               ephemeral-storage: {{ .Values.podTypes.rayHeadType.storage }}
-              {{- if .Values.podTypes.rayHeadType.GPU }}
-              nvidia.com/gpu: {{ .Values.podTypes.rayHeadType.GPU }}
+              {{- if .Values.podTypes.rayWorkerType.GPU }}
+              nvidia.com/gpu: {{ .Values.podTypes.rayWorkerType.GPU }}
               {{- end }}
 {{- end }}


### PR DESCRIPTION
apparently, re: nvidia.com/gpu requests/limits, on nodes with 8 gpus:

no request: get 8, according to nvidia-smi, but 0 according to kubectl get quota
request 0: same
request 1: get 1, according to nvidia-smi *and* kubectl get quota

oof, so for now we need to assign gpus to the head, if we are assigning them to the worker.

i'm not sure what happens when using a gpu-enabled image but not desiring to use gpus... we'll have to cross that bridge when we come to it