### PR TITLE
fix: ray port-forward may spin loop

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/port-forward/ray-with-cluster.md
+++ b/guidebooks/ml/ray/start/kubernetes/port-forward/ray-with-cluster.md
@@ -2,6 +2,7 @@
 imports:
     - util/shuf
     - kubernetes/choose/ns
+    - ml/ray/cluster/head
 ---
 
 # Port-forward to the Ray API
@@ -10,12 +11,21 @@ To facilitate communication to the Ray API, we establish a
 port-forward to a selected Ray cluster.
 
 ```shell.async
+# Ray port-forward
 N=1
 SLEEP=1
 while true; do
     svc=${RAY_KUBE_CLUSTER_HEAD_SERVICE-ray-head-${RAY_KUBE_CLUSTER_NAME-mycluster}}
-    kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward --pod-running-timeout=24h service/$svc ${RAY_KUBE_PORT-8266}:8265 > /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} || sleep $SLEEP
-    if [ "$N" -lt 10 ]; then SLEEP=10; fi
+    kubectl ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} port-forward --pod-running-timeout=24h service/$svc ${RAY_KUBE_PORT-8266}:8265 > /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster}
+    
+    state=$(kubectl get pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${RAY_HEAD_POD} --no-headers -o custom-columns=STATUS:.status.phase)
+    if [[ "$state" != "Running" ]] && [[ "$state" != "Pending" ]]; then
+      # the underlying pod is no longer running, we can give up
+      break
+    fi
+
+    sleep $SLEEP
+    if [[ "$N" -lt 10 ]]; then SLEEP=10; fi
     N=$((N + 1))
 done
 ```
@@ -27,15 +37,23 @@ done
 ### Wait for the ray port forwarder to become active
 
 ```shell
+# Wait for Ray port-forward to become active
 N=1
 SLEEP=1
 while true; do 
-    if [ -f /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} ] && [ "$(cat /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} | grep -q 'Forwarding from' && echo 1 || echo 0)" = "1" ]; then
+    if [[ -f /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} ]] && [[ "$(cat /tmp/port-forward-ray-${RAY_KUBE_CLUSTER_NAME-mycluster} | grep -q 'Forwarding from' && echo 1 || echo 0)" = "1" ]]; then
       break
     else
-      sleep 1
+      sleep $SLEEP
     fi
-    if [ "$N" -lt 10 ]; then SLEEP=10; fi
+
+    state=$(kubectl get pod ${KUBE_CONTEXT_ARG} ${KUBE_NS_ARG} ${RAY_HEAD_POD} --no-headers -o custom-columns=STATUS:.status.phase)
+    if [[ "$state" != "Running" ]] && [[ "$state" != "Pending" ]]; then
+      # the underlying pod is no longer running, we can give up
+      break
+    fi
+    
+    if [[ "$N" -lt 10 ]]; then SLEEP=10; fi
     N=$((N + 1))
 done
 


### PR DESCRIPTION
this fixes non-sleepy spinlooping
it also fixes the situation where the pod is no longer running, and gives up rather than emit bad errors