### PR TITLE
fix: ray jobs emit job env.json only after job is running

### DIFF
--- a/guidebooks/ml/ray/run/logs.md
+++ b/guidebooks/ml/ray/run/logs.md
@@ -8,10 +8,6 @@ imports:
 We will stream out a suite of data, including resource utilization metrics and job logs.
 
 
-## Capture Environment Variables
-
---8<-- "./job-env.md"
-
 ## Stream Resource Metrics
 
 --8<-- "./pod-stats.md"

--- a/guidebooks/ml/ray/start/kubernetes.md
+++ b/guidebooks/ml/ray/start/kubernetes.md
@@ -6,6 +6,7 @@ imports:
     - kubernetes/choose/ns
     - ./kubernetes/name
     - ./kubernetes/events
+    - ml/ray/run/job-env
     - ./kubernetes/install-via-helm
     - ml/ray/start/kubernetes/self-destruct
 ---


### PR DESCRIPTION
this means we cannot extract any env info during setup