### PR TITLE
fix: lower custodian logs container 100m/128Mi -> 50m/32Mi

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/custodian/custodian.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/custodian/custodian.yaml
@@ -18,19 +18,13 @@ spec:
       serviceAccountName: ray-self-destruct-v1-sa-${USER-genericuser}
       imagePullSecrets:
         - name: ${IMAGE_PULL_SECRET-none}
-      # securityContext:
-      #   seccompProfile:
-      #     type: RuntimeDefault
       containers:
       - name: logs
         image: $CUSTODIAN_IMAGE
-        env:
-          - name: RAY_ADDRESS
-            value: ray-head-$RAY_KUBE_CLUSTER_NAME:6379
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: 50m
+            memory: 32Mi
         command: [ "/bin/bash", "-c", "--" ]
         args:
           - "kubectl logs -f -l $KUBE_JOB_LOGS_LABEL_SELECTOR; echo 'Job run is complete'; sleep ${CUSTODIAN_DELETE_DELAY-10}; echo 'Tearing down cluster, if needed'; helm delete -n ${KUBE_NS_FOR_REAL-${KUBE_NS}} $RAY_KUBE_CLUSTER_NAME 2>&1 | grep -v 'Release not loaded' || exit 0"


### PR DESCRIPTION
this also removes the RAY_ADDRESS env var from the logs pod, as it is no longer needed (we now use `kubectl logs` to stream out the logs)