### PR TITLE
fix: improve custodian memory requests for larger jobs

### DIFF
--- a/guidebooks/ml/codeflare/custodian/containers/cpu/container.yaml
+++ b/guidebooks/ml/codeflare/custodian/containers/cpu/container.yaml
@@ -4,7 +4,7 @@
         resources:
           limits:
             cpu: 50m
-            memory: 96Mi
+            memory: $CUSTODIAN_MEMORY
         command: [ "/bin/bash", "-c", "--" ]
         args:
           - |

--- a/guidebooks/ml/codeflare/custodian/containers/cpu/cpu.sh
+++ b/guidebooks/ml/codeflare/custodian/containers/cpu/cpu.sh
@@ -3,4 +3,4 @@
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} -o name \
         --field-selector=status.phase==Running \
     | xargs -P512 -I {} -n1 \
-            sh -c 'kubectl exec {} -- sh -c "TZ=UTC vmstat --timestamp 5" | awk -v pod={} -f /tmp/cpu.awk'
+            sh -c 'kubectl exec {} -- sh -c "TZ=UTC vmstat --timestamp 5" | awk -v pod={} -f /tmp/cpu.awk' 2> /dev/null

--- a/guidebooks/ml/codeflare/custodian/containers/gpu/container.yaml
+++ b/guidebooks/ml/codeflare/custodian/containers/gpu/container.yaml
@@ -4,7 +4,7 @@
         resources:
           limits:
             cpu: 50m
-            memory: 96Mi
+            memory: $CUSTODIAN_MEMORY
         command: [ "/bin/bash", "-c", "--" ]
         args:
           - |

--- a/guidebooks/ml/codeflare/custodian/containers/gpu/gpu.sh
+++ b/guidebooks/ml/codeflare/custodian/containers/gpu/gpu.sh
@@ -3,4 +3,5 @@
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} -o name \
         --field-selector=status.phase==Running \
     | xargs -P512 -I {} -n1 \
-            sh -c 'kubectl exec {} -- sh -c "nvidia-smi --query-gpu=timestamp,utilization.gpu,utilization.memory,memory.total,temperature.gpu,name --format=csv,noheader -l 10" | awk -v pod={} -F, -f /tmp/gpu.awk'
+            sh -c 'kubectl exec {} -- sh -c "nvidia-smi --query-gpu=timestamp,utilization.gpu,utilization.memory,memory.total,temperature.gpu,name --format=csv,noheader -l 10" | awk -v pod={} -F, -f /tmp/gpu.awk' \
+            2> /dev/null

--- a/guidebooks/ml/codeflare/custodian/containers/logs/container.yaml
+++ b/guidebooks/ml/codeflare/custodian/containers/logs/container.yaml
@@ -8,7 +8,7 @@
         command: [ "/bin/bash", "-c", "--" ]
         args:
           - |
-            kubectl logs -f -l $KUBE_JOB_LOGS_LABEL_SELECTOR
+            kubectl logs --max-log-requests=${MAX_WORKERS-5} --tail=10000 -f -l $KUBE_JOB_LOGS_LABEL_SELECTOR
             echo 'Job run is complete'
             sleep ${CUSTODIAN_DELETE_DELAY-10}
             echo 'Tearing down cluster, if needed'

--- a/guidebooks/ml/codeflare/custodian/containers/mem/container.yaml
+++ b/guidebooks/ml/codeflare/custodian/containers/mem/container.yaml
@@ -4,7 +4,7 @@
         resources:
           limits:
             cpu: 50m
-            memory: 96Mi
+            memory: $CUSTODIAN_MEMORY
         command: [ "/bin/bash", "-c", "--" ]
         args:
           - |

--- a/guidebooks/ml/codeflare/custodian/containers/mem/memory.sh
+++ b/guidebooks/ml/codeflare/custodian/containers/mem/memory.sh
@@ -3,4 +3,5 @@
 kubectl get pod -l ${KUBE_PODFULL_LABEL_SELECTOR} -o name \
         --field-selector=status.phase==Running \
     | xargs -P512 -I {} -n1 \
-            sh -c 'kubectl exec {} -- sh -c "while true; do echo \"\$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.current) \$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.max) \$(date -u +%Y-%m-%dT%H:%M:%SZ)\"; sleep 5; done" | awk -v pod={} -f /tmp/memory.awk'
+            sh -c 'kubectl exec {} -- sh -c "while true; do echo \"\$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.current) \$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.max) \$(date -u +%Y-%m-%dT%H:%M:%SZ)\"; sleep 5; done" | awk -v pod={} -f /tmp/memory.awk' \
+            2> /dev/null

--- a/guidebooks/ml/codeflare/custodian/index.md
+++ b/guidebooks/ml/codeflare/custodian/index.md
@@ -12,17 +12,8 @@ imports:
 
 TMPFILE=$(mktemp)
 
-# WORKER STATUS
-cat << EOF | base64 | tr -d '\n' > $TMPFILE
---8<-- "./containers/status/worker-status.sh"
-EOF
-export WORKER_STATUS_B64=$(cat $TMPFILE)
-
-# RUNTIME ENV SETUP
-cat << EOF | base64 | tr -d '\n' > $TMPFILE
---8<-- "./containers/runtime-env/runtime-env-setup.sh"
-EOF
-export RUNTIME_ENV_B64=$(cat $TMPFILE)
+# for pods that need memory proportional to num workers
+export CUSTODIAN_MEMORY="$((32 + $MAX_WORKERS * 20))Mi"
 
 # CPU FILES
 cat << 'EOF' | base64 | tr -d '\n' > $TMPFILE
@@ -48,8 +39,6 @@ YAML=$(mktemp)
 cat << EOF > $YAML
 --8<-- "./custodian.yaml"
 --8<-- "./containers/logs/container.yaml"
---8<-- "./containers/status/container.yaml"
---8<-- "./containers/runtime-env/container.yaml"
 --8<-- "./containers/cpu/container.yaml"
 --8<-- "./containers/mem/container.yaml"
 EOF
@@ -70,6 +59,29 @@ cat << EOF >> $YAML
 EOF
 fi
 
+# WORKER STATUS FILES
+if [[ "$APP_API" = "ray" ]]; then
+cat << EOF | base64 | tr -d '\n' > $TMPFILE
+--8<-- "./containers/status/worker-status.sh"
+EOF
+export WORKER_STATUS_B64=$(cat $TMPFILE)
+
+cat << EOF >> $YAML
+--8<-- "./containers/status/container.yaml"
+EOF
+fi
+
+# RUNTIME ENV SETUP
+if [[ "$APP_API" = "ray" ]]; then
+cat << EOF | base64 | tr -d '\n' > $TMPFILE
+--8<-- "./containers/runtime-env/runtime-env-setup.sh"
+EOF
+export RUNTIME_ENV_B64=$(cat $TMPFILE)
+
+cat << EOF >> $YAML
+--8<-- "./containers/runtime-env/container.yaml"
+EOF
+fi
 kubectl apply $KUBE_CONTEXT_ARG $KUBE_NS_ARG -f $YAML
 
 rm -f $YAML $TMPFILE

--- a/guidebooks/ml/ray/start/kubernetes/name.md
+++ b/guidebooks/ml/ray/start/kubernetes/name.md
@@ -1,6 +1,10 @@
 The name of the Ray Kubernetes Service.
 
 ```shell
+export APP_API=ray
+```
+
+```shell
 export RAY_KUBE_CLUSTER_NAME=$(echo ${RAY_KUBE_CLUSTER_NAME-${APP_NAME-${USER-myapp}}-${JOB_ID}} | cut -c1-50 | tr '[:upper:]' '[:lower:]')
 ```
 


### PR DESCRIPTION
We had been using a fixed amount of memory for the cpu/mem/gpu trackers. But these need memory per worker (since we connect to each worker).

This also updates the `kubectl logs` in the logs container to pass in a `--max-logs-requests` that is set to num workers for the run.

This also fixes some issues with the custodian vs torchx jobs, to avoid tracking worker status and runtime env setup (since, for now, those are ray-specific).