### PR TITLE
fix: avoid helm delete in custodian for now

### DIFF
--- a/guidebooks/ml/codeflare/custodian/containers/logs/container.yaml
+++ b/guidebooks/ml/codeflare/custodian/containers/logs/container.yaml
@@ -11,5 +11,5 @@
             kubectl logs --max-log-requests=$((1 + ${MAX_WORKERS-5})) --tail=10000 -f $KUBE_JOB_LOGS_LABEL_SELECTOR --all-containers
             echo 'Job run is complete'
             sleep ${CUSTODIAN_DELETE_DELAY-10}
-            echo 'Tearing down cluster, if needed'
-            helm delete -n ${KUBE_NS_FOR_REAL-${KUBE_NS}} $RAY_KUBE_CLUSTER_NAME 2>&1 | grep -v 'Release not loaded' || exit 0
+            # echo 'Tearing down cluster, if needed'
+            # helm delete -n ${KUBE_NS_FOR_REAL-${KUBE_NS}} $RAY_KUBE_CLUSTER_NAME 2>&1 | grep -v 'Release not loaded' || exit 0


### PR DESCRIPTION
if there is a network disconnect, we cannot delete the job resources

this is a short-term fix. the real fix is to figure out how to be more resilient to network disconnects.