### PR TITLE
fix: multinic detection was broken; also was hard-wiring name of resource

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -22,7 +22,7 @@ spec:
       namespace: {{ .Values.clusterNamespace }}
       annotations:
         {{- if .Values.multinic }}
-        k8s.v1.cni.cncf.io/networks: multi-nic-network
+        k8s.v1.cni.cncf.io/networks: {{ .Values.multinic }}
         {{- end }}
       labels:
         component: ray-head

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
@@ -13,7 +13,7 @@ spec:
     metadata:
       annotations:
         {{- if .Values.multinic }}
-        k8s.v1.cni.cncf.io/networks: multi-nic-network
+        k8s.v1.cni.cncf.io/networks: {{ .Values.multinic }}
         {{- end }}
       labels:
         component: ray-worker

--- a/guidebooks/ml/torchx/run/invoke-torchx.sh
+++ b/guidebooks/ml/torchx/run/invoke-torchx.sh
@@ -38,9 +38,12 @@ elif [[ "$KUBE_POD_SCHEDULING_PRIO" = "low-priority" ]]; then
     prio=",priority=1,priority_class_name=$KUBE_POD_SCHEDULING_PRIO"
 fi
 
-if kubectl ${KUBE_CONTEXT_ARG} api-resources | grep multinicnetworks >& /dev/null; then
-   multinic=",network=multi-nic-network"
+set +e
+multinicName=$(kubectl ${KUBE_CONTEXT_ARG} get --no-headers network-attachment-definitions.k8s.cni.cncf.io -o custom-columns=NAME:.metadata.name 2> /dev/null | head -1)
+if [[ $? = 0 ]]; then
+   multinic=",network=$multinicName"
 fi
+set -e
 
 if [[ -n "$TORCHX_MOUNTS" ]]; then
     mounts="--mounts $(echo "$TORCHX_MOUNTS" | sed 's/,$//')"


### PR DESCRIPTION
With this PR, we no longer hard-wire the name of the multinic resource, but we are always choosing the first one. TODO: do we need to make this (yet another) choice? so that the user chooses with multinic resource to use? hmm