### PR TITLE
Update pvc.yaml - add diskfree parameter

### DIFF
--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/pvc.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/pvc.yaml
@@ -13,6 +13,7 @@ metadata:
         ibm.io/secret-name: {{ $val.secret }}
         ibm.io/endpoint: {{ $val.endpoint }}
         ibm.io/tls-cipher-suite: "default" # https://github.com/IBM/ibmcloud-object-storage-plugin/issues/110
+        ibm.io/add-mount-param: 'ensure_diskfree=20000'
 spec:
     accessModes:
         - ReadWriteMany


### PR DESCRIPTION
Prevent s3fs from utilizing all available disk space for cache.  Sets min available free space to 20GB on the filesystem being used to cache reads from COS.