### PR TITLE
feat: Update to mcad v1.34.1 support and torchx 0.6.0

### DIFF
--- a/guidebooks/kubernetes/mcad/install/mcad.sh
+++ b/guidebooks/kubernetes/mcad/install/mcad.sh
@@ -1,17 +1,16 @@
 WORKDIR=$(mktemp -d) && cd $WORKDIR
 
 GITHUB=github.com
-#ORG=IBM
-ORG=starpit
+ORG=project-codeflare
 REPO=multi-cluster-app-dispatcher
-#BRANCH=quota-management
-BRANCH=002
+BRANCH=v1.34.1
+LOCAL=multi-cluster-app-dispatcher
 SUBDIR=deployment/mcad-controller
 
 echo "Installing Advanced Pod Manager"
 
 # sparse clone
-if [ -n "$BRANCH" ]; then BRANCHOPT="-b $BRANCH"; fi
+if [ -n "$BRANCH" ]; then BRANCHOPT="-b $BRANCH $LOCAL"; fi
 (git clone -q --no-checkout --filter=blob:none https://${GITHUB}/${ORG}/${REPO}.git ${BRANCHOPT} && \
     cd $REPO && \
     git sparse-checkout set --cone $SUBDIR && git checkout ${BRANCH-master})
@@ -24,16 +23,17 @@ if [ -n "$CI" ]; then
     RESOURCES="--set resources.limits.cpu=200m --set resources.requests.cpu=200m --set resources.limits.memory=750Mi --set resources.requests.memory=750Mi"
 fi
 
-IMAGE=darroyo/mcad-controller
+IMAGE=quay.io/project-codeflare/mcad-controller
 cd $REPO/$SUBDIR &&
     helm upgrade --install --wait mcad . \
          ${KUBE_CONTEXT_ARG_HELM} ${RESOURCES} \
          --namespace kube-system \
          --set loglevel=4 \
          --set image.repository=$IMAGE \
-         --set image.tag=quota-management-v1.29.40 \
+         --set image.tag=release-v1.34.1 \
          --set image.pullPolicy=IfNotPresent \
          --set configMap.name=mcad-controller-configmap \
          --set configMap.quotaEnabled='"false"' \
+         --set configMap.preemptionEnabled='"true"' \
          --set coscheduler.rbac.apiGroup="scheduling.sigs.k8s.io" \
          --set coscheduler.rbac.resource="podgroups"

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_head-deployment.tpl
@@ -8,7 +8,7 @@ metadata:
     component: ray-head
     type: ray
     ray-cluster-name: {{ .Values.clusterName }}
-    appwrapper.mcad.ibm.com: {{ .Values.clusterName }}
+    appwrapper.workload.codeflare.dev: {{ .Values.clusterName }}
     app.kubernetes.io/name: {{ .Values.clusterName }}
     app.kubernetes.io/instance: {{ .Values.clusterName }}
     app.kubernetes.io/owner: {{ .Values.userName | default "unknown" }}
@@ -27,7 +27,7 @@ spec:
       labels:
         component: ray-head
         type: ray
-        appwrapper.mcad.ibm.com: {{ .Values.clusterName }}
+        appwrapper.workload.codeflare.dev: {{ .Values.clusterName }}
         app.kubernetes.io/name: {{ .Values.clusterName }}
         app.kubernetes.io/instance: {{ .Values.clusterName }}
         app.kubernetes.io/owner: {{ .Values.userName | default "unknown" }}

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/_worker-deployment.tpl
@@ -18,7 +18,7 @@ spec:
       labels:
         component: ray-worker
         type: ray
-        appwrapper.mcad.ibm.com: {{ .Values.clusterName }}
+        appwrapper.workload.codeflare.dev: {{ .Values.clusterName }}
         app.kubernetes.io/name: {{ .Values.clusterName }}
         app.kubernetes.io/instance: {{ .Values.clusterName }}
         app.kubernetes.io/owner: {{ .Values.userName | default "unknown" }}

--- a/guidebooks/ml/ray/start/kubernetes/chart/templates/ray.yaml
+++ b/guidebooks/ml/ray/start/kubernetes/chart/templates/ray.yaml
@@ -19,7 +19,7 @@
 
 {{- else }}
 {{- if .Values.mcad.enabled }}
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: workload.codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   name: {{ .Values.clusterName }}

--- a/guidebooks/ml/torchx/install/cli.md
+++ b/guidebooks/ml/torchx/install/cli.md
@@ -32,5 +32,5 @@ if which pip3.10; then
 fi
 --8<-- "./activate.sh"
 pip3 --version
-pip3 install "torchx[dev]==${TORCHX_PIP_VERSION}"
+pip3 install "torchx==${TORCHX_PIP_VERSION}" "kubernetes==${KUBERNETES_PIP_VERSION}"
 ```

--- a/guidebooks/ml/torchx/install/path.md
+++ b/guidebooks/ml/torchx/install/path.md
@@ -1,5 +1,9 @@
 ```shell
-export TORCHX_PIP_VERSION=${TORCHX_PIP_VERSION-0.5.0}
+export TORCHX_PIP_VERSION=${TORCHX_PIP_VERSION-0.6.0}
+```
+
+```shell
+export KUBERNETES_PIP_VERSION=${KUBERNETES_PIP_VERSION-18.20.0}
 ```
 
 python 3.9.6 on macOS does not handle spaces in the venv path, and on

--- a/guidebooks/ml/torchx/run/instance-label.md
+++ b/guidebooks/ml/torchx/run/instance-label.md
@@ -1,5 +1,5 @@
 ```shell
-export TORCHX_INSTANCE_LABEL=appwrapper.mcad.ibm.com=${TORCHX_INSTANCE}
+export TORCHX_INSTANCE_LABEL=appwrapper.workload.codeflare.dev=${TORCHX_INSTANCE}
 ```
 
 ```shell


### PR DESCRIPTION
Summary: MCAD V1.34.1 changed the Appwrapper crd. 

This PR updates:

- appwrapper.mcad.ibm.com -> appwrapper.workload.codeflare.dev
- Any group API indicators to workload.codeflare.dev
- MCAD installation to v1.34.1, including controller repository and image
- TorchX and related dependencies to TorchX=0.6.0 which will feature MCAD V1.34.1 support